### PR TITLE
fix: add cache control to email reputation API request and refactor form reset handling

### DIFF
--- a/src/app/api/send-mail/route.js
+++ b/src/app/api/send-mail/route.js
@@ -62,7 +62,7 @@ export async function POST(req) {
       try {
         const abstractRes = await fetch(
           `https://emailreputation.abstractapi.com/v1/?api_key=${process.env.ABSTRACT_API_KEY}&email=${encodeURIComponent(email)}`,
-          { signal: controller.signal },
+          { signal: controller.signal, cache: 'no-store' },
         );
 
         if (abstractRes.ok) {

--- a/src/components/contact/Form.jsx
+++ b/src/components/contact/Form.jsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -22,11 +22,20 @@ const item = {
 
 function FormContent({ onReset }) {
   const [launch, setLaunch] = useState('idle');
+  const timersRef = useRef([]);
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm();
+
+  useEffect(() => {
+    return () => timersRef.current.forEach(clearTimeout);
+  }, []);
+
+  const schedule = (cb, ms) => {
+    timersRef.current.push(setTimeout(cb, ms));
+  };
 
   const sendEmail = async (params) => {
     try {
@@ -70,11 +79,11 @@ function FormContent({ onReset }) {
       setLaunch('rocket');
       // Deterministic state machine: timeouts aligned with animation durations
       // Rocket: 0.6s delay + 1.4s fly-up = ~2s, Checkmark: 0.5s enter + 2s display
-      setTimeout(() => setLaunch('check'), 2000);
+      schedule(() => setLaunch('check'), 2000);
       // Remount the entire form component to get a fresh useForm() instance.
       // This avoids the known issue where reset() inside handleSubmit's callback
       // gets its state overridden by handleSubmit's finally block.
-      setTimeout(() => onReset(), 4500);
+      schedule(onReset, 4500);
     } else {
       setLaunch('idle');
     }

--- a/src/components/contact/Form.jsx
+++ b/src/components/contact/Form.jsx
@@ -20,13 +20,12 @@ const item = {
   show: { scale: 1 },
 };
 
-export default function Form() {
+function FormContent({ onReset }) {
   const [launch, setLaunch] = useState('idle');
   const {
     register,
     handleSubmit,
     formState: { errors },
-    reset,
   } = useForm();
 
   const sendEmail = async (params) => {
@@ -72,10 +71,10 @@ export default function Form() {
       // Deterministic state machine: timeouts aligned with animation durations
       // Rocket: 0.6s delay + 1.4s fly-up = ~2s, Checkmark: 0.5s enter + 2s display
       setTimeout(() => setLaunch('check'), 2000);
-      setTimeout(() => {
-        reset(); // called outside handleSubmit stack so isSubmitted is fully cleared
-        setLaunch('idle');
-      }, 4500);
+      // Remount the entire form component to get a fresh useForm() instance.
+      // This avoids the known issue where reset() inside handleSubmit's callback
+      // gets its state overridden by handleSubmit's finally block.
+      setTimeout(() => onReset(), 4500);
     } else {
       setLaunch('idle');
     }
@@ -98,7 +97,7 @@ export default function Form() {
           <label htmlFor="name" className="sr-only">
             Full Name
           </label>
-          <motion.input
+          <input
             id="name"
             name="name"
             type="text"
@@ -134,7 +133,7 @@ export default function Form() {
           <label htmlFor="email" className="sr-only">
             Email
           </label>
-          <motion.input
+          <input
             id="email"
             name="email"
             type="email"
@@ -160,7 +159,7 @@ export default function Form() {
           <label htmlFor="subject" className="sr-only">
             Subject
           </label>
-          <motion.input
+          <input
             id="subject"
             name="subject"
             type="text"
@@ -192,7 +191,7 @@ export default function Form() {
           <label htmlFor="message" className="sr-only">
             Message
           </label>
-          <motion.textarea
+          <textarea
             id="message"
             name="message"
             placeholder="Message"
@@ -327,4 +326,11 @@ export default function Form() {
       </motion.form>
     </>
   );
+}
+
+// Wrapper that remounts FormContent via key after a successful send.
+// This gives useForm() a completely fresh instance — no stale state.
+export default function Form() {
+  const [formKey, setFormKey] = useState(0);
+  return <FormContent key={formKey} onReset={() => setFormKey((k) => k + 1)} />;
 }


### PR DESCRIPTION
This pull request refactors the contact form component to address state management issues and simplify input handling. The main changes include replacing motion components with standard HTML inputs, restructuring the form to allow remounting to restore a clean state after submission, and improving API request-caching behaviour.

**Contact form refactoring and state management:**

* Replaces all `motion.input` and `motion.textarea` elements with standard HTML `input` and `textarea` elements in `Form.jsx` to simplify the code and avoid unnecessary animation overhead. [[1]](diffhunk://#diff-ab38abb01de0b3c624fb7cf13fd0484f54bcef5be34b3f4b33625e29e07237f0L101-R100) [[2]](diffhunk://#diff-ab38abb01de0b3c624fb7cf13fd0484f54bcef5be34b3f4b33625e29e07237f0L137-R136) [[3]](diffhunk://#diff-ab38abb01de0b3c624fb7cf13fd0484f54bcef5be34b3f4b33625e29e07237f0L163-R162) [[4]](diffhunk://#diff-ab38abb01de0b3c624fb7cf13fd0484f54bcef5be34b3f4b33625e29e07237f0L195-R194)
* Refactors the form component by extracting the form logic into a new `FormContent` component and introducing a wrapper that remounts `FormContent` via a changing `key` after a successful send. This ensures a completely fresh `useForm()` instance and resolves issues with `reset()` not fully clearing state after submission. [[1]](diffhunk://#diff-ab38abb01de0b3c624fb7cf13fd0484f54bcef5be34b3f4b33625e29e07237f0L23-L29) [[2]](diffhunk://#diff-ab38abb01de0b3c624fb7cf13fd0484f54bcef5be34b3f4b33625e29e07237f0L75-R77) [[3]](diffhunk://#diff-ab38abb01de0b3c624fb7cf13fd0484f54bcef5be34b3f4b33625e29e07237f0R330-R336)

**API request improvement:**

* Updates the fetch request in `send-mail/route.js` to include `{ cache: 'no-store' }`, ensuring that email reputation checks are always performed with fresh data and not cached responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Email reputation API now fetches fresh validation data instead of cached results, ensuring accurate checks
  * Contact form now properly resets and clears all fields after a message is successfully sent

* **Style**
  * Simplified contact form input field interactions by removing animation effects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->