### PR TITLE
fix: adjust textarea rows and enable vertical resizing in contact form

### DIFF
--- a/src/components/contact/Form.jsx
+++ b/src/components/contact/Form.jsx
@@ -203,6 +203,7 @@ function FormContent({ onReset }) {
           <textarea
             id="message"
             name="message"
+            rows={5}
             placeholder="Message"
             aria-invalid={Boolean(errors.message)}
             aria-describedby={errors.message ? 'message-error' : undefined}
@@ -217,7 +218,7 @@ function FormContent({ onReset }) {
                 message: 'Message should be more than 50 characters',
               },
             })}
-            className="custom-bg-2 w-full rounded-md p-2 text-foreground shadow-lg hover:shadow-[0_0_15px_#5c0099] focus:shadow-[0_0_10px_rgba(155,89,182,0.6)] focus:outline-none focus:ring-1 focus:ring-[rgba(155,89,182,0.8)]"
+            className="custom-bg-2 w-full resize-y rounded-md p-2 text-foreground shadow-lg hover:shadow-[0_0_15px_#5c0099] focus:shadow-[0_0_10px_rgba(155,89,182,0.6)] focus:outline-none focus:ring-1 focus:ring-[rgba(155,89,182,0.8)]"
           />
         </motion.div>
         {errors.message && (


### PR DESCRIPTION
This pull request makes minor improvements to the contact form's message textarea. The changes enhance the user experience by allowing the textarea to be resized and setting a default number of visible rows.

- **User experience improvements in the contact form:**
  * The message `textarea` now has a default of 5 visible rows, making it easier for users to write longer messages.
  * The `textarea` is now resizable vertically (`resize-y`), allowing users to adjust its height as needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact form message textarea with better default sizing and vertical resizing capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->