### PR TITLE
fix: update animation timing for contact form transition

### DIFF
--- a/src/components/contact/Form.jsx
+++ b/src/components/contact/Form.jsx
@@ -9,8 +9,8 @@ const container = {
   show: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.3,
-      delayChildren: 0.2,
+      staggerChildren: 0.45,
+      delayChildren: 0.3,
     },
   },
 };

--- a/src/components/contact/Form.jsx
+++ b/src/components/contact/Form.jsx
@@ -16,8 +16,22 @@ const container = {
 };
 
 const item = {
-  hidden: { scale: 0 },
-  show: { scale: 1 },
+  hidden: { opacity: 0, scale: 0.85 },
+  show: {
+    opacity: 1,
+    scale: 1,
+    transition: {
+      duration: 0.5,
+      ease: 'easeOut',
+      scale: {
+        type: 'keyframes',
+        values: [0.85, 1.06, 0.97, 1.02, 1],
+        times: [0, 0.35, 0.55, 0.75, 1],
+        duration: 0.6,
+        ease: 'easeInOut',
+      },
+    },
+  },
 };
 
 function FormContent({ onReset }) {

--- a/src/components/contact/Form.jsx
+++ b/src/components/contact/Form.jsx
@@ -19,13 +19,10 @@ const item = {
   hidden: { opacity: 0, scale: 0.85 },
   show: {
     opacity: 1,
-    scale: 1,
+    scale: [0.85, 1.06, 0.97, 1.02, 1],
     transition: {
-      duration: 0.5,
-      ease: 'easeOut',
+      opacity: { duration: 0.4, ease: 'easeOut' },
       scale: {
-        type: 'keyframes',
-        values: [0.85, 1.06, 0.97, 1.02, 1],
         times: [0, 0.35, 0.55, 0.75, 1],
         duration: 0.6,
         ease: 'easeInOut',


### PR DESCRIPTION
This pull request makes a minor adjustment to the animation timing in the contact form component, increasing both the stagger and the delay between child animations to achieve a smoother entrance effect.

- Animation timing update:
  * In `src/components/contact/Form.jsx`, increased `staggerChildren` from 0.3 to 0.45 and `delayChildren` from 0.2 to 0.3 in the `container` animation configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined contact form animation timing for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->