### PR TITLE
fix: update GitHub Actions to use checkout and setup-node v5

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Use the default GITHUB_TOKEN — no PAT required
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest major versions of key actions. The main focus is upgrading both the `actions/checkout` and `actions/setup-node` actions from version 4 to version 5 across all workflows to ensure improved security, reliability, and access to the latest features.

**CI/CD workflow updates:**

* Updated `actions/checkout` from `v4` to `v5` in `.github/workflows/ai-code-review.yml`, `.github/workflows/ci.yml`, and `.github/workflows/sync-readme.yml` for more secure and reliable code checkout. [[1]](diffhunk://#diff-ac9faf9e08f5e50cc2754167e51c90e5d7a1b5403ceb5fb807650fa108078721L17-R20) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL34-R37) [[3]](diffhunk://#diff-eff8b66a2a1c589a12e57303b7147f0d82fe4b5d1f42bc7743a0143ee5f3421aL29-R37)
* Updated `actions/setup-node` from `v4` to `v5` in all workflows to leverage the latest Node.js setup improvements and bug fixes. [[1]](diffhunk://#diff-ac9faf9e08f5e50cc2754167e51c90e5d7a1b5403ceb5fb807650fa108078721L17-R20) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL34-R37) [[3]](diffhunk://#diff-eff8b66a2a1c589a12e57303b7147f0d82fe4b5d1f42bc7743a0143ee5f3421aL29-R37)