### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
       - name: Open / update README sync PR
         if: steps.diff.outputs.changed == 'true'
         id: pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'docs: sync README dependency versions'


### PR DESCRIPTION
## Summary
Bumps three GitHub Actions to their Node 24 majors to clear the upcoming Node 20 deprecation warnings (Node 20 removed from runners on **Sep 16, 2026**).

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v5` | `v6` |
| `actions/setup-node` | `v5` | `v6` |
| `peter-evans/create-pull-request` | `v7` | `v8` |

## Compatibility
- `actions/checkout@v6` — no breaking changes for this repo (release notes: README + credential persistence improvements only).
- `actions/setup-node@v6` — single breaking change is "limit automatic caching to npm". This repo already uses `cache: 'npm'`, so unaffected.
- `peter-evans/create-pull-request@v8` — no input changes; just internally bumped to checkout v6 and Node 24.

Touches all three workflows: `sync-readme.yml`, `ai-code-review.yml`, `ci.yml`.

## Test plan
- [ ] Merge this PR, confirm CI on main goes green.
- [ ] Manually trigger `Sync README` from the Actions tab — confirm no Node 20 deprecation annotation.
