### PR TITLE
feat: enhance title styling for Architect of Enchantment with custom colors and effects

### DIFF
--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -177,7 +177,16 @@ const AboutDetails = () => {
             " col-span-full lg:col-span-8 row-span-2 flex-col items-start"
           }
         >
-          <h2 className="text-xl md:text-2xl text-left w-full capitalize text-shadow-neon-orange">
+          <h2
+            className="text-xl md:text-2xl text-left w-full capitalize"
+            style={{
+              color: '#ffb347',
+              WebkitTextStroke: '0.5px #ff8c1a',
+              filter:
+                'drop-shadow(0 0 6px rgba(255, 140, 26, 0.55)) drop-shadow(0 0 14px rgba(255, 140, 26, 0.32))',
+              textShadow: 'none',
+            }}
+          >
             Architect of Enchantment
           </h2>
           <p style={{ textShadow: "none" }} className="font-light text-xs sm:text-sm md:text-base text-shadow-neon-light-orange">

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -181,10 +181,10 @@ const AboutDetails = () => {
             className="text-xl md:text-2xl text-left w-full capitalize"
             style={{
               color: '#ffb347',
-              WebkitTextStroke: '0.5px #ff8c1a',
-              filter:
-                'drop-shadow(0 0 6px rgba(255, 140, 26, 0.55)) drop-shadow(0 0 14px rgba(255, 140, 26, 0.32))',
               textShadow: 'none',
+              WebkitFontSmoothing: 'antialiased',
+              MozOsxFontSmoothing: 'grayscale',
+              textRendering: 'geometricPrecision',
             }}
           >
             Architect of Enchantment


### PR DESCRIPTION
This pull request updates the visual styling of the "Architect of Enchantment" heading in the `AboutDetails` component to use inline styles for a more customised neon-orange effect, replacing the previous Tailwind CSS class.

Visual styling improvements:

* Updated the `<h2>` heading in `AboutDetails` to use inline styles for colour, text stroke, and drop-shadow effects, replacing the `text-shadow-neon-orange` Tailwind class for a more precise neon-orange appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the "Architect of Enchantment" heading to refine its appearance with adjusted text effects and glow presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->