### PR TITLE
feat: implement custom 404 page with immersive visuals and interactive elements

### DIFF
--- a/src/app/(sub pages)/projects/[id]/page.js
+++ b/src/app/(sub pages)/projects/[id]/page.js
@@ -8,6 +8,7 @@ import { motion } from "framer-motion"
 import * as THREE from "three"
 import Image from "next/image"
 import { projectsData } from "@/app/data"
+import { notFound } from "next/navigation"
 import RealisticTree from "@/components/project-detail/tree-stump"
 import LaptopModel from "@/components/project-detail/laptop-model"
 import bg from "../../../../../public/background/home-bg.png"
@@ -122,12 +123,17 @@ export default function ThreeDScene({ params }) {
     const { id } = params
     const project = projectsData.find((p) => p.id === parseInt(id))
 
+    // Invalid / non-existent project id (e.g. /projects/9999 or
+    // /projects/abc → parseInt → NaN → find returns undefined).
+    // `notFound()` throws NEXT_NOT_FOUND which bubbles up to the
+    // nearest not-found boundary — in our case the root
+    // app/not-found.js, so the user lands on the void/glitch 404
+    // with the correct HTTP 404 status, and the analytics
+    // `404_hit` event fires automatically. Replaces the previous
+    // inline "Project not found." div which returned HTTP 200 and
+    // was indexable by search engines.
     if (!project) {
-        return (
-            <div className="w-full h-screen flex items-center justify-center bg-black text-[#ff6d05] text-3xl">
-                Project not found.
-            </div>
-        )
+        notFound()
     }
 
     return (

--- a/src/app/(sub pages)/projects/[id]/page.js
+++ b/src/app/(sub pages)/projects/[id]/page.js
@@ -121,17 +121,31 @@ function Scene() {
 
 export default function ThreeDScene({ params }) {
     const { id } = params
-    const project = projectsData.find((p) => p.id === parseInt(id))
+    // Strict integer-string check before lookup. Two reasons:
+    //   1. parseInt was permissive — parseInt("1abc", 10) === 1,
+    //      so /projects/1abc would silently resolve to project 1
+    //      with HTTP 200. Number("1abc") returns NaN instead, and
+    //      Number.isInteger(NaN) is false, so we notFound() it.
+    //   2. The `String(parsedId) === id` round-trip also rejects
+    //      non-canonical forms (/projects/01, /projects/1.0,
+    //      /projects/1e0) that Number() would otherwise accept —
+    //      every valid project has exactly ONE canonical URL,
+    //      preventing duplicate-content URLs from being indexed.
+    const parsedId = Number(id)
+    const isStrictInteger =
+        Number.isInteger(parsedId) && String(parsedId) === id
+    const project = isStrictInteger
+        ? projectsData.find((p) => p.id === parsedId)
+        : undefined
 
-    // Invalid / non-existent project id (e.g. /projects/9999 or
-    // /projects/abc → parseInt → NaN → find returns undefined).
-    // `notFound()` throws NEXT_NOT_FOUND which bubbles up to the
-    // nearest not-found boundary — in our case the root
-    // app/not-found.js, so the user lands on the void/glitch 404
-    // with the correct HTTP 404 status, and the analytics
-    // `404_hit` event fires automatically. Replaces the previous
-    // inline "Project not found." div which returned HTTP 200 and
-    // was indexable by search engines.
+    // Invalid / non-existent project id (e.g. /projects/9999,
+    // /projects/abc, /projects/1abc, /projects/01). `notFound()`
+    // throws NEXT_NOT_FOUND which bubbles up to the root
+    // app/not-found.js boundary, so the user lands on the void
+    // /glitch 404 with the correct HTTP 404 status, and the
+    // analytics `404_hit` event fires automatically. Replaces the
+    // previous inline "Project not found." div which returned
+    // HTTP 200 and was indexable by search engines.
     if (!project) {
         notFound()
     }

--- a/src/app/data.js
+++ b/src/app/data.js
@@ -116,8 +116,13 @@ export const BtnList = [
     newTab: false,
   },
   {
+    // Intentionally routes to an unmatched path so Next.js renders the
+    // custom 404 (src/app/not-found.js) — the previous portfolio link
+    // is retired and the void aesthetic now stands in for it. If/when
+    // a real "My Past" page is added, create src/app/(sub pages)/my-past/
+    // and this entry will start resolving to it without any other change.
     label: 'My Past',
-    link: 'https://muhammadabdullah227.co.uk/',
+    link: '/my-past',
     icon: 'past',
     newTab: false,
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -600,13 +600,18 @@ html {
 
    Three layers:
    • The base `<h1>` carries the stroke + glow
-   • `::before` (amethyst-neon) — chromatic aberration shifted
-     left, clipped to the upper portion of the glyph
-   • `::after`  (ember-neon)    — shifted right, lower portion
-   Together they produce a CRT-corruption tri-tone whose
-   subtle continuous offset is barely visible at rest, but
-   amplifies during the scramble burst driven by GlitchText.jsx
-   (see `.glitch-text.scrambling`). */
+   • `::before` (amethyst-neon) — shifted left, clipped to the
+     LEFT 35% of the glyph (via `inset(0 65% 0 0)` — i.e.
+     hide the right 65%)
+   • `::after`  (ember-neon)    — shifted right, clipped to the
+     RIGHT 35% of the glyph (via `inset(0 0 0 65%)` — i.e.
+     hide the left 65%)
+   The two layers therefore overlap visually only in the middle
+   ~30% column of the glyph, where the base orange stroke shows
+   through. That horizontal split is the classic CRT chromatic
+   aberration: subtle continuous offset is barely visible at
+   rest, but amplifies during the scramble burst driven by
+   GlitchText.jsx (see `.glitch-text.scrambling`). */
 .glitch-text {
   position: relative;
   display: inline-block;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -563,3 +563,225 @@ html {
     animation: none !important;
   }
 }
+
+/* ── 404 / not-found page ─────────────────────────────────
+   Custom 404 page for issue #39. Standalone immersive screen
+   with a glitching "404", CSS-only drifting particles, and a
+   radial-vignette void background. Kept in globals.css (not a
+   CSS module) because: (1) the glitch effect uses ::before /
+   ::after pseudo-elements driven by a `data-text` attribute,
+   which can't be expressed in inline styles or Tailwind, and
+   (2) particle keyframes need to be globally available to the
+   inline `animation-duration` / `animation-delay` props on
+   each particle element. */
+
+.not-found-bg {
+  /* Subtle off-centre vignette draws the eye toward the
+     vertical-mid-upper area where the "404" sits, leaving the
+     rest darker so particles feel like they're drifting through
+     deeper space at the edges.
+
+     Gradient uses the brand's dark tones — ember-950 (#1b100f,
+     a warm near-black) at the centre fading to night-950
+     (#01050b, the cool deep-blue-black) at the edges — so the
+     void reads as the same universe as the rest of the site
+     rather than a generic black box. */
+  background: radial-gradient(ellipse at 50% 40%, #1b100f 0%, #01050b 70%);
+  min-height: 100vh;
+}
+
+/* ── Glitch text ──
+   The "404" uses the site's SIGNATURE text style: transparent
+   fill, 3px ember-neon stroke, multi-layer ember drop-shadow
+   glow — the same `text-glow-stroke-neon` language as the
+   homepage "MUHAMMAD ABDULLAH" headline. Pulling that look in
+   verbatim means the 404 reads as the same brand voice, not a
+   separate decorative widget.
+
+   Three layers:
+   • The base `<h1>` carries the stroke + glow
+   • `::before` (amethyst-neon) — chromatic aberration shifted
+     left, clipped to the upper portion of the glyph
+   • `::after`  (ember-neon)    — shifted right, lower portion
+   Together they produce a CRT-corruption tri-tone whose
+   subtle continuous offset is barely visible at rest, but
+   amplifies during the scramble burst driven by GlitchText.jsx
+   (see `.glitch-text.scrambling`). */
+.glitch-text {
+  position: relative;
+  display: inline-block;
+  font-family: var(--font-varela-round), sans-serif;
+  font-size: clamp(7rem, 20vw, 15rem);
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: 4px;
+  color: transparent;
+  -webkit-text-stroke: 3px #ff6d05;
+  filter:
+    drop-shadow(0 0 10px rgba(255, 106, 0, 0.8))
+    drop-shadow(0 0 20px rgba(255, 106, 0, 0.6))
+    drop-shadow(0 0 30px rgba(255, 90, 0, 0.4));
+  transition: filter 0.3s ease;
+  animation: glitch-skew 4s infinite linear alternate-reverse;
+}
+
+.glitch-text::before,
+.glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  /* Pseudo layers also use transparent fill + their own stroke
+     colour, so the chromatic aberration reads as coloured
+     OUTLINES splitting from the orange base — not coloured
+     fills bleeding over the top. */
+  color: transparent;
+}
+
+.glitch-text::before {
+  -webkit-text-stroke: 2px #fc83ff;
+  animation: glitch-left 3s infinite linear alternate-reverse;
+  clip-path: inset(0 65% 0 0);
+}
+
+.glitch-text::after {
+  -webkit-text-stroke: 2px #eab53e;
+  animation: glitch-right 2.5s infinite linear alternate-reverse;
+  clip-path: inset(0 0 0 65%);
+}
+
+@keyframes glitch-left {
+  0%, 90% { transform: translate(0); }
+  91% { transform: translate(-4px, 2px); }
+  92% { transform: translate(2px, -1px); }
+  93% { transform: translate(-2px, 0); }
+  94%, 100% { transform: translate(0); }
+}
+
+@keyframes glitch-right {
+  0%, 88% { transform: translate(0); }
+  89% { transform: translate(3px, -2px); }
+  90% { transform: translate(-3px, 1px); }
+  91% { transform: translate(1px, 2px); }
+  92%, 100% { transform: translate(0); }
+}
+
+@keyframes glitch-skew {
+  0%, 87% { transform: skew(0deg); }
+  88% { transform: skew(0.5deg); }
+  89% { transform: skew(-0.3deg); }
+  90%, 100% { transform: skew(0deg); }
+}
+
+/* ── Scramble + resolve burst ──
+   While GlitchText.jsx is rapidly swapping the displayed digits
+   through random characters, `.scrambling` is applied: the
+   chromatic aberration ::before/::after layers shift more
+   aggressively (heavy CRT-corruption mode) and the base glow
+   destabilises. When the scramble resolves to "404", JS swaps
+   `.scrambling` for `.pulse-resolve` for 700ms — a single
+   bright glow surge that mimics the homepage ring ripple's
+   peak, giving the resolve real weight rather than just
+   stopping. */
+.glitch-text.scrambling {
+  animation: glitch-skew 0.15s infinite linear alternate-reverse;
+}
+.glitch-text.scrambling::before {
+  animation: glitch-scramble-left 0.18s infinite linear;
+}
+.glitch-text.scrambling::after {
+  animation: glitch-scramble-right 0.2s infinite linear;
+}
+
+.glitch-text.pulse-resolve {
+  animation: glitch-pulse 0.7s ease-out;
+}
+
+@keyframes glitch-scramble-left {
+  0%   { transform: translate(-6px, 3px); }
+  25%  { transform: translate(4px, -2px); }
+  50%  { transform: translate(-3px, 1px); }
+  75%  { transform: translate(5px, -3px); }
+  100% { transform: translate(-4px, 2px); }
+}
+
+@keyframes glitch-scramble-right {
+  0%   { transform: translate(5px, -2px); }
+  25%  { transform: translate(-4px, 3px); }
+  50%  { transform: translate(2px, -3px); }
+  75%  { transform: translate(-5px, 1px); }
+  100% { transform: translate(4px, -2px); }
+}
+
+@keyframes glitch-pulse {
+  0% {
+    filter:
+      drop-shadow(0 0 10px rgba(255, 106, 0, 0.8))
+      drop-shadow(0 0 20px rgba(255, 106, 0, 0.6))
+      drop-shadow(0 0 30px rgba(255, 90, 0, 0.4));
+    transform: scale(1);
+  }
+  30% {
+    filter:
+      drop-shadow(0 0 20px rgba(255, 109, 5, 1))
+      drop-shadow(0 0 40px rgba(255, 109, 5, 0.95))
+      drop-shadow(0 0 80px rgba(255, 109, 5, 0.7))
+      drop-shadow(0 0 120px rgba(252, 131, 255, 0.4));
+    transform: scale(1.04);
+  }
+  100% {
+    filter:
+      drop-shadow(0 0 10px rgba(255, 106, 0, 0.8))
+      drop-shadow(0 0 20px rgba(255, 106, 0, 0.6))
+      drop-shadow(0 0 30px rgba(255, 90, 0, 0.4));
+    transform: scale(1);
+  }
+}
+
+/* ── 404 amethyst firefly orbs ──
+   Layered ABOVE the global FireFliesBackground (which paints
+   ember orbs on every page). Same `firefly-life` lifecycle so
+   the breathing is in sympathy, but tinted amethyst — the
+   void-page signature. Each orb's radial gradient colour is
+   set inline via `--orb-color` so a small fraction can be
+   ember orbs for cohesion without forking the CSS. */
+.not-found-orb {
+  position: absolute;
+  border-radius: 9999px;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    var(--orb-color, rgba(252, 131, 255, 0.55)) 0%,
+    transparent 100%
+  );
+  /* `infinite` so each orb cycles continuously; randomised
+     `animation-delay` per orb (set inline) means the field as
+     a whole feels organic, not synced. */
+  animation: firefly-life var(--life-dur, 5s) ease-in-out var(--life-delay, 0s) infinite;
+  will-change: opacity, transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glitch-text,
+  .glitch-text::before,
+  .glitch-text::after {
+    animation: none;
+    /* Stroke + glow remain (drop-shadow filter doesn't depend
+       on animation), so static readers still see a glowing
+       "404" — just without the periodic shake/scramble. */
+  }
+  .glitch-text.scrambling,
+  .glitch-text.scrambling::before,
+  .glitch-text.scrambling::after {
+    animation: none;
+  }
+  .glitch-text.pulse-resolve {
+    animation: none;
+  }
+  .not-found-orb {
+    animation: none;
+    opacity: 0.4;
+  }
+}

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -1,0 +1,15 @@
+import NotFoundClient from '@/components/not-found/NotFoundClient';
+
+// Server component on purpose — exporting `metadata` only works
+// from server components, and the validation checklist requires
+// the document `<title>` to be set during SSR. All interactivity
+// lives behind the 'use client' boundary inside NotFoundClient.
+export const metadata = {
+  title: '404 — Page Not Found | theabdullahfolio',
+  description:
+    "You've drifted into the void. This page doesn't exist — yet.",
+};
+
+export default function NotFound() {
+  return <NotFoundClient />;
+}

--- a/src/components/not-found/FloatingParticles.jsx
+++ b/src/components/not-found/FloatingParticles.jsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// Mostly amethyst (the void-page signature) with a small ember
+// minority so the field still feels like a continuation of the
+// global FireFliesBackground (which is all ember orange).
+const AMETHYST = 'rgba(252, 131, 255, 0.55)'; // amethyst-neon
+const AMETHYST_DIM = 'rgba(252, 131, 255, 0.35)';
+const EMBER = 'rgba(255, 109, 5, 0.5)';       // neon-700
+
+const ORB_COUNT = 22;
+const AMETHYST_RATIO = 0.8; // 80% amethyst, 20% ember
+
+function makeOrbs() {
+  return Array.from({ length: ORB_COUNT }, (_, i) => {
+    const isAmethyst = Math.random() < AMETHYST_RATIO;
+    const tint = isAmethyst
+      ? Math.random() < 0.5
+        ? AMETHYST
+        : AMETHYST_DIM
+      : EMBER;
+    return {
+      id: i,
+      top: `${Math.random() * 100}%`,
+      left: `${Math.random() * 100}%`,
+      // Size 6–16px — larger than the previous 1–4px dots so
+      // the radial glow reads as a glowing orb, not a pixel.
+      size: 6 + Math.random() * 10,
+      // 5–11s full lifecycle. Longer than the global firefly's
+      // 3.5–7s so the 404 orbs feel slower / lonelier than the
+      // hero's bustling fireflies — "you've drifted further out
+      // where time runs differently".
+      lifeDur: 5 + Math.random() * 6,
+      // Stagger delays across the full life range so the field
+      // is in different lifecycle phases at any given moment —
+      // no synchronised "all bright at the same instant" pulse.
+      lifeDelay: -(Math.random() * 6),
+      tint,
+    };
+  });
+}
+
+/**
+ * Amethyst firefly orbs layered above the global
+ * FireFliesBackground. Each orb uses the existing
+ * `firefly-life` keyframe (defined in globals.css) so its
+ * breathing rhythm is in sympathy with the rest of the site's
+ * ambient particles — but tinted amethyst (with a sprinkle of
+ * ember) so the 404 reads as a stranger, sparser pocket of
+ * the same universe rather than a separate decorative scheme.
+ *
+ * Generated client-side only — Math.random on the server would
+ * produce a different value tree than on the client, which
+ * would trigger a hydration mismatch warning.
+ */
+export default function FloatingParticles() {
+  const [orbs, setOrbs] = useState([]);
+
+  useEffect(() => {
+    setOrbs(makeOrbs());
+  }, []);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 overflow-hidden"
+    >
+      {orbs.map((o) => (
+        <div
+          key={o.id}
+          className="not-found-orb"
+          style={{
+            top: o.top,
+            left: o.left,
+            width: `${o.size}px`,
+            height: `${o.size}px`,
+            '--life-dur': `${o.lifeDur}s`,
+            '--life-delay': `${o.lifeDelay}s`,
+            '--orb-color': o.tint,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/not-found/GlitchText.jsx
+++ b/src/components/not-found/GlitchText.jsx
@@ -134,23 +134,55 @@ export default function GlitchText({ text = '404', parallax }) {
 
   return (
     <motion.div
-      initial={{ opacity: 0, scale: 0.8, y: 20 }}
+      // Same gating pattern as every other entrance on this page:
+      // reduced-motion users render directly at the `animate`
+      // target via `initial={false}`, no transition. Both `scale`
+      // and `y` would otherwise run a transform-based entrance,
+      // which is exactly what vestibular users want suppressed.
+      initial={
+        prefersReducedMotion
+          ? false
+          : { opacity: 0, scale: 0.8, y: 20 }
+      }
       animate={{ opacity: 1, scale: 1, y: 0 }}
-      transition={{ duration: 0.6, ease: 'easeOut' }}
-      style={transformStyle}
+      transition={
+        prefersReducedMotion
+          ? { duration: 0 }
+          : { duration: 0.6, ease: 'easeOut' }
+      }
       className="select-none"
-      // Keep a single accessible name on the live heading so
-      // assistive tech reads "404", not whatever random trio is
-      // currently mid-scramble.
-      aria-label={text}
     >
-      <h1
-        className={`glitch-text ${stateClass}`}
-        data-text={displayed}
-        aria-hidden="true"
-      >
-        {displayed}
-      </h1>
+      {/* The parallax transform lives on a NESTED wrapper, not on
+          the motion.div above, so framer-motion has exclusive
+          ownership of the outer element's `style.transform` for
+          its entrance animation (scale + y). If we set the
+          parallax on the same element framer animates, both
+          would be writing to the single `style.transform`
+          property — last write wins, and during the 0.6s entrance
+          + the 0.7s `.pulse-resolve` scale we'd see the parallax
+          clobber framer mid-animation (visible as a snap back to
+          parallax-only translation). With the parallax on its own
+          element, the browser stacks the transforms through the
+          DOM and they compose cleanly. */}
+      <div style={transformStyle}>
+        {/* Accessible name lives on the heading itself (not on the
+            wrappers above) so the <h1> stays in the document
+            outline and assistive tech can jump to it via the
+            headings rotor. `aria-label` overrides the visible text
+            content for AT, which is exactly what we want during a
+            scramble — the visible "#7$" never reaches a screen
+            reader; users always hear "404". The pseudo-element
+            chromatic layers read their content from `data-text`
+            so they continue to mirror the live visual without
+            affecting the announced name. */}
+        <h1
+          className={`glitch-text ${stateClass}`}
+          data-text={displayed}
+          aria-label={text}
+        >
+          {displayed}
+        </h1>
+      </div>
     </motion.div>
   );
 }

--- a/src/components/not-found/GlitchText.jsx
+++ b/src/components/not-found/GlitchText.jsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+
+// Character pool the digits cycle through during a scramble.
+// Mostly digits so the field still reads as "numeric data
+// corrupting" rather than a Matrix rain. Two glyph symbols
+// (`#`, `*`) for visual texture without breaking that read.
+const SCRAMBLE_CHARS = '0123456789#*';
+const SCRAMBLE_FRAME_MS = 50;     // per-frame interval (≈20fps)
+const SCRAMBLE_FRAMES = 14;       // ≈700ms of scrambling
+const PULSE_MS = 700;             // duration of the resolve flash
+const IDLE_MIN_MS = 6000;         // shortest gap between scrambles
+const IDLE_MAX_MS = 9000;         // longest gap
+
+function pickRandomChar() {
+  return SCRAMBLE_CHARS[Math.floor(Math.random() * SCRAMBLE_CHARS.length)];
+}
+
+function randomTrio() {
+  return pickRandomChar() + pickRandomChar() + pickRandomChar();
+}
+
+/**
+ * "404" with two layered behaviours:
+ *
+ * 1. CONTINUOUS — pseudo-element chromatic aberration (defined
+ *    in globals.css as `.glitch-text::before` / `::after`) runs
+ *    subtle offset shakes in the background. ~90% of every loop
+ *    the layers are aligned, ~10% they jitter — periodic noise
+ *    rather than seizure-inducing flicker.
+ *
+ * 2. PERIODIC SCRAMBLE — every 6–9s this component flips into
+ *    "scrambling" phase: the displayed text rapidly cycles
+ *    through random characters for ≈700ms (slot-machine /
+ *    CRT-corruption feel), then snaps back to "404" with a
+ *    bright ember-pulse glow burst lasting another ≈700ms. The
+ *    scramble runs even when the user isn't looking, so the
+ *    "surprise" is reliable on first paint and on return.
+ *
+ * Reduced-motion users skip the scramble entirely — they see a
+ * static, stroked "404" with the brand's drop-shadow glow.
+ *
+ * @param {Object} props
+ * @param {string} [props.text='404']  Final resolved text. Also
+ *                                     used as the initial render
+ *                                     so SSR + first paint match.
+ * @param {{x:number,y:number}} [props.parallax]
+ *                                     Optional translate offset
+ *                                     applied to the wrapper
+ *                                     (so it composes with the
+ *                                     internal scale-pulse on the
+ *                                     resolve animation without
+ *                                     either clobbering the other).
+ */
+export default function GlitchText({ text = '404', parallax }) {
+  const [displayed, setDisplayed] = useState(text);
+  // 'idle' — showing `text` with subtle continuous glitch only
+  // 'scrambling' — rapidly cycling through random chars
+  // 'resolving' — `text` is shown again + pulse burst running
+  const [phase, setPhase] = useState('idle');
+  const prefersReducedMotion = useReducedMotion() ?? false;
+
+  // Refs let cleanup cancel pending timers even mid-scramble,
+  // so a fast unmount (e.g. user clicks TAKE ME BACK) doesn't
+  // leave a setInterval running and spamming state into an
+  // unmounted tree.
+  const idleTimerRef = useRef(null);
+  const scrambleTimerRef = useRef(null);
+  const pulseTimerRef = useRef(null);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      // Reduced motion: render static target text, never scramble.
+      setDisplayed(text);
+      setPhase('idle');
+      return undefined;
+    }
+
+    const clearAll = () => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      if (scrambleTimerRef.current) clearInterval(scrambleTimerRef.current);
+      if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+    };
+
+    const scheduleNextScramble = () => {
+      const delay = IDLE_MIN_MS + Math.random() * (IDLE_MAX_MS - IDLE_MIN_MS);
+      idleTimerRef.current = setTimeout(beginScramble, delay);
+    };
+
+    const beginScramble = () => {
+      setPhase('scrambling');
+      // Render the first scrambled frame immediately so the user
+      // sees a change the moment the scramble fires (without
+      // this the first 50ms still show the previous "404").
+      setDisplayed(randomTrio());
+      let frame = 1;
+      scrambleTimerRef.current = setInterval(() => {
+        if (frame >= SCRAMBLE_FRAMES) {
+          clearInterval(scrambleTimerRef.current);
+          scrambleTimerRef.current = null;
+          resolveToTarget();
+          return;
+        }
+        setDisplayed(randomTrio());
+        frame += 1;
+      }, SCRAMBLE_FRAME_MS);
+    };
+
+    const resolveToTarget = () => {
+      setDisplayed(text);
+      setPhase('resolving');
+      pulseTimerRef.current = setTimeout(() => {
+        setPhase('idle');
+        scheduleNextScramble();
+      }, PULSE_MS);
+    };
+
+    scheduleNextScramble();
+    return clearAll;
+  }, [prefersReducedMotion, text]);
+
+  const transformStyle = parallax
+    ? { transform: `translate(${parallax.x}px, ${parallax.y}px)` }
+    : undefined;
+
+  const stateClass =
+    phase === 'scrambling'
+      ? 'scrambling'
+      : phase === 'resolving'
+      ? 'pulse-resolve'
+      : '';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.8, y: 20 }}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
+      style={transformStyle}
+      className="select-none"
+      // Keep a single accessible name on the live heading so
+      // assistive tech reads "404", not whatever random trio is
+      // currently mid-scramble.
+      aria-label={text}
+    >
+      <h1
+        className={`glitch-text ${stateClass}`}
+        data-text={displayed}
+        aria-hidden="true"
+      >
+        {displayed}
+      </h1>
+    </motion.div>
+  );
+}

--- a/src/components/not-found/NotFoundClient.jsx
+++ b/src/components/not-found/NotFoundClient.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { Briefcase, Phone, User } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -44,15 +44,28 @@ export default function NotFoundClient() {
   const [messageIndex, setMessageIndex] = useState(0);
   const [parallax, setParallax] = useState({ x: 0, y: 0 });
   const [hasHover, setHasHover] = useState(false);
+  // Single source of truth for "skip ongoing motion effects". Used
+  // by the rotating subtitle and mouse parallax below; the visual
+  // ambient effects (orbs, glitch scramble) honour the same media
+  // query via their own components or via CSS in globals.css.
+  const prefersReducedMotion = useReducedMotion();
 
   // Rotating subtitle. AnimatePresence in the JSX swaps the active
   // message with a vertical fade — index increments every 5s.
+  //
+  // Skipped entirely for reduced-motion users: the interval never
+  // starts, the index stays at 0, and AnimatePresence never sees
+  // a key change — so they get a single stable line ("You've
+  // drifted into the void.") rather than a 5-second crossfade
+  // cycle that would conflict with the rest of the page's
+  // reduced-motion stack.
   useEffect(() => {
+    if (prefersReducedMotion) return undefined;
     const id = setInterval(() => {
       setMessageIndex((i) => (i + 1) % ROTATING_MESSAGES.length);
     }, MESSAGE_ROTATION_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [prefersReducedMotion]);
 
   // Detect pointer-fine + hover-capable input so the mouse parallax
   // doesn't run on touch devices (where the only event source would
@@ -65,10 +78,14 @@ export default function NotFoundClient() {
     return () => mql.removeEventListener('change', update);
   }, []);
 
-  // Mouse parallax — bound only when the device supports hover, so
-  // we avoid a no-op `mousemove` listener on phones/tablets.
+  // Mouse parallax — bound only when the device (a) supports
+  // hover/pointer-fine input AND (b) the user hasn't asked for
+  // reduced motion. Parallax produces continuous animated content
+  // changes in response to input, which is exactly the kind of
+  // motion vestibular users want suppressed, so the reduced-motion
+  // check matters even on hover-capable hardware.
   useEffect(() => {
-    if (!hasHover) return;
+    if (!hasHover || prefersReducedMotion) return undefined;
     const handleMouse = (e) => {
       setParallax({
         x: (e.clientX / window.innerWidth - 0.5) * PARALLAX_AMPLITUDE_PX * 2,
@@ -77,18 +94,33 @@ export default function NotFoundClient() {
     };
     window.addEventListener('mousemove', handleMouse);
     return () => window.removeEventListener('mousemove', handleMouse);
-  }, [hasHover]);
+  }, [hasHover, prefersReducedMotion]);
 
-  // Keyboard shortcut: H or Escape returns home. Guard against
-  // firing while the user is typing in an input (none on this page
-  // today, but cheap insurance if a future enhancement adds one).
+  // Keyboard shortcut: H or Escape returns home. Several guards
+  // before we actually route:
+  //   • Skip while the user is typing in an input/textarea/
+  //     contenteditable so typing the letter "h" never yanks them
+  //     off the page. None on this page today, but cheap insurance.
+  //   • Skip if another handler has already called preventDefault
+  //     on this event — respect the existing intent.
+  //   • Skip on key repeat so holding H doesn't spam router.push
+  //     30+ times/second during the navigation that's already in
+  //     flight.
+  //   • Skip when Cmd/Ctrl/Alt is held: Cmd+H on macOS hides the
+  //     app, Ctrl+H in Chrome/Firefox opens history. Both would
+  //     break user expectations if we hijacked them. Shift is
+  //     intentionally NOT in the skip list — Shift+H just yields
+  //     capital "H" and is still a valid way to type the shortcut.
   useEffect(() => {
     const handleKey = (e) => {
       const tag = e.target?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable) {
         return;
       }
-      if (e.key === 'h' || e.key === 'H' || e.key === 'Escape') {
+      if (e.defaultPrevented || e.repeat || e.metaKey || e.ctrlKey || e.altKey) {
+        return;
+      }
+      if (e.key === 'Escape' || e.key.toLowerCase() === 'h') {
         router.push('/');
       }
     };
@@ -102,13 +134,26 @@ export default function NotFoundClient() {
   // (mistyped URLs, stale bookmarks, broken inbound links) become
   // discoverable in the dashboard rather than silently rotting.
   //
-  // Only the pathname is sent — search params are intentionally
-  // omitted because query strings can contain PII (session tokens,
-  // email addresses in unsubscribe links, etc.) and we don't want
-  // that leaking into analytics.
+  // Both values are sanitised before sending:
+  //   • `path` strips query/hash because query strings can carry
+  //     PII (session tokens, emails in unsubscribe links, JWT
+  //     reset tokens, etc.).
+  //   • `referrer` is parsed and reduced to `origin + pathname` —
+  //     same reasoning: the raw value can carry the SAME PII from
+  //     whichever page sent the user here. Malformed referrers
+  //     fall through to '(invalid)' rather than crashing or
+  //     leaking the broken string.
   useEffect(() => {
     const path = window.location.pathname;
-    const referrer = document.referrer || '(direct)';
+    let referrer = '(direct)';
+    if (document.referrer) {
+      try {
+        const parsed = new URL(document.referrer);
+        referrer = `${parsed.origin}${parsed.pathname}`;
+      } catch {
+        referrer = '(invalid)';
+      }
+    }
     track('404_hit', { path, referrer });
   }, []);
 
@@ -126,7 +171,15 @@ export default function NotFoundClient() {
       <FloatingParticles />
 
       <div className="relative z-10 flex flex-col items-center gap-6">
-        <GlitchText text="404" parallax={hasHover ? parallax : undefined} />
+        <GlitchText
+          text="404"
+          // Match the same gate as the mouse listener above —
+          // passing `{x:0,y:0}` would attach an inline transform
+          // to the heading that silently clobbers the pulse-resolve
+          // scale animation, so we forward `undefined` whenever
+          // parallax isn't actually being driven.
+          parallax={hasHover && !prefersReducedMotion ? parallax : undefined}
+        />
 
         <div className="flex min-h-[6rem] flex-col items-center gap-2">
           {/* Top subtitle: rotates every 5s. AnimatePresence handles
@@ -137,10 +190,21 @@ export default function NotFoundClient() {
             <AnimatePresence mode="wait">
               <motion.p
                 key={messageIndex}
-                initial={{ opacity: 0, y: 10 }}
+                // Entrance + exit both use `y` transforms, so both
+                // are gated on reduced-motion. The rotation interval
+                // is already gated upstream (messageIndex never
+                // changes for reduced-motion users), so in practice
+                // `exit` never fires either way — but defining it
+                // safely keeps the contract clean if a future change
+                // re-introduces rotation.
+                initial={
+                  prefersReducedMotion ? false : { opacity: 0, y: 10 }
+                }
                 animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -10 }}
-                transition={{ duration: 0.4 }}
+                exit={prefersReducedMotion ? undefined : { opacity: 0, y: -10 }}
+                transition={
+                  prefersReducedMotion ? { duration: 0 } : { duration: 0.4 }
+                }
                 className="text-base text-foreground/60 sm:text-lg"
               >
                 {ROTATING_MESSAGES[messageIndex]}
@@ -149,9 +213,13 @@ export default function NotFoundClient() {
           </div>
 
           <motion.p
-            initial={{ opacity: 0, y: 8 }}
+            initial={prefersReducedMotion ? false : { opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.8, duration: 0.5 }}
+            transition={
+              prefersReducedMotion
+                ? { duration: 0 }
+                : { delay: 0.8, duration: 0.5 }
+            }
             className="text-sm text-foreground/40 sm:text-base"
           >
             This page doesn&apos;t exist — yet.
@@ -161,9 +229,13 @@ export default function NotFoundClient() {
         <ReturnPortal />
 
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={prefersReducedMotion ? false : { opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 1.5, duration: 0.5 }}
+          transition={
+            prefersReducedMotion
+              ? { duration: 0 }
+              : { delay: 1.5, duration: 0.5 }
+          }
           className="mt-4 flex flex-wrap items-center justify-center gap-3"
         >
           {SUGGESTIONS.map(({ label, href, Icon }) => (

--- a/src/components/not-found/NotFoundClient.jsx
+++ b/src/components/not-found/NotFoundClient.jsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Briefcase, Phone, User } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { track } from '@vercel/analytics';
+
+import FloatingParticles from './FloatingParticles';
+import GlitchText from './GlitchText';
+import ReturnPortal from './ReturnPortal';
+
+const ROTATING_MESSAGES = [
+  "You've drifted into the void.",
+  'This page is in another dimension.',
+  "Even my 3D skills couldn't render this page.",
+  '404: page not found, vibes still immaculate.',
+  "You've reached the edge of the portfolio.",
+];
+
+const SUGGESTIONS = [
+  { label: 'About', href: '/about', Icon: User },
+  { label: 'Projects', href: '/projects', Icon: Briefcase },
+  { label: 'Contact', href: '/contact', Icon: Phone },
+];
+
+const PARALLAX_AMPLITUDE_PX = 10;
+const MESSAGE_ROTATION_MS = 5000;
+
+/**
+ * Orchestrator for the 404 page. Composes the visual layers
+ * (particles → glitch → subtitles → portal → suggestions) and
+ * owns the small bits of state that span them: rotating message
+ * index, mouse parallax offset, and the keyboard shortcut.
+ *
+ * Lives in `src/components/not-found/` rather than directly in
+ * `not-found.js` so the page file can stay a server component
+ * (and export a `metadata` object for the document <title>),
+ * while all the interactivity lives behind a 'use client' boundary.
+ */
+export default function NotFoundClient() {
+  const router = useRouter();
+  const [messageIndex, setMessageIndex] = useState(0);
+  const [parallax, setParallax] = useState({ x: 0, y: 0 });
+  const [hasHover, setHasHover] = useState(false);
+
+  // Rotating subtitle. AnimatePresence in the JSX swaps the active
+  // message with a vertical fade — index increments every 5s.
+  useEffect(() => {
+    const id = setInterval(() => {
+      setMessageIndex((i) => (i + 1) % ROTATING_MESSAGES.length);
+    }, MESSAGE_ROTATION_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  // Detect pointer-fine + hover-capable input so the mouse parallax
+  // doesn't run on touch devices (where the only event source would
+  // be `mousemove`s synthesised from taps, producing a janky lurch).
+  useEffect(() => {
+    const mql = window.matchMedia('(hover: hover) and (pointer: fine)');
+    const update = () => setHasHover(mql.matches);
+    update();
+    mql.addEventListener('change', update);
+    return () => mql.removeEventListener('change', update);
+  }, []);
+
+  // Mouse parallax — bound only when the device supports hover, so
+  // we avoid a no-op `mousemove` listener on phones/tablets.
+  useEffect(() => {
+    if (!hasHover) return;
+    const handleMouse = (e) => {
+      setParallax({
+        x: (e.clientX / window.innerWidth - 0.5) * PARALLAX_AMPLITUDE_PX * 2,
+        y: (e.clientY / window.innerHeight - 0.5) * PARALLAX_AMPLITUDE_PX * 2,
+      });
+    };
+    window.addEventListener('mousemove', handleMouse);
+    return () => window.removeEventListener('mousemove', handleMouse);
+  }, [hasHover]);
+
+  // Keyboard shortcut: H or Escape returns home. Guard against
+  // firing while the user is typing in an input (none on this page
+  // today, but cheap insurance if a future enhancement adds one).
+  useEffect(() => {
+    const handleKey = (e) => {
+      const tag = e.target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable) {
+        return;
+      }
+      if (e.key === 'h' || e.key === 'H' || e.key === 'Escape') {
+        router.push('/');
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [router]);
+
+  // Operational observability — record the path that triggered
+  // this 404, plus the referrer that brought the user here. Lands
+  // in the Vercel Analytics custom-events feed so dead links
+  // (mistyped URLs, stale bookmarks, broken inbound links) become
+  // discoverable in the dashboard rather than silently rotting.
+  //
+  // Only the pathname is sent — search params are intentionally
+  // omitted because query strings can contain PII (session tokens,
+  // email addresses in unsubscribe links, etc.) and we don't want
+  // that leaking into analytics.
+  useEffect(() => {
+    const path = window.location.pathname;
+    const referrer = document.referrer || '(direct)';
+    track('404_hit', { path, referrer });
+  }, []);
+
+  // Console easter egg — devs who inspect the page get a nod and a
+  // pointer to the source. Logged once per mount.
+  useEffect(() => {
+    console.log(
+      '%c🚀 Looking for something? Source: github.com/MA1002643/theabdullahfolio',
+      'color: #ff6d05; font-size: 14px; font-weight: bold;',
+    );
+  }, []);
+
+  return (
+    <main className="not-found-bg relative isolate flex min-h-screen flex-col items-center justify-center overflow-hidden px-4 py-12 text-center">
+      <FloatingParticles />
+
+      <div className="relative z-10 flex flex-col items-center gap-6">
+        <GlitchText text="404" parallax={hasHover ? parallax : undefined} />
+
+        <div className="flex min-h-[6rem] flex-col items-center gap-2">
+          {/* Top subtitle: rotates every 5s. AnimatePresence handles
+              the vertical fade crossfade between messages.
+              `min-h` on the parent prevents the layout below from
+              shifting when message text length changes. */}
+          <div className="flex h-7 items-center">
+            <AnimatePresence mode="wait">
+              <motion.p
+                key={messageIndex}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.4 }}
+                className="text-base text-foreground/60 sm:text-lg"
+              >
+                {ROTATING_MESSAGES[messageIndex]}
+              </motion.p>
+            </AnimatePresence>
+          </div>
+
+          <motion.p
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.8, duration: 0.5 }}
+            className="text-sm text-foreground/40 sm:text-base"
+          >
+            This page doesn&apos;t exist — yet.
+          </motion.p>
+        </div>
+
+        <ReturnPortal />
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 1.5, duration: 0.5 }}
+          className="mt-4 flex flex-wrap items-center justify-center gap-3"
+        >
+          {SUGGESTIONS.map(({ label, href, Icon }) => (
+            <Link
+              key={href}
+              href={href}
+              prefetch={false}
+              className="custom-bg inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-xs uppercase tracking-wider text-foreground/50 transition-all duration-300 hover:border-[#ff6d05]/60 hover:text-ember-halo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff6d05]"
+            >
+              <Icon className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden="true" />
+              {label}
+            </Link>
+          ))}
+        </motion.div>
+      </div>
+
+      {/* Keyboard hint — gated on `hasHover` (true only when the
+          device reports both hover-capable and pointer-fine input,
+          via the same matchMedia query that powers the mouse
+          parallax above). That hides the hint on every touch-only
+          device — phone OR tablet — and shows it the moment a
+          device actually has a real pointer (laptop, desktop, or
+          a tablet with Magic Keyboard / Surface keyboard attached).
+          Strictly more correct than a width breakpoint: an iPad in
+          portrait at 1024×768 is still touch-only and shouldn't
+          claim an "H" key.
+
+          The keydown listener for H/Escape stays bound on every
+          device — the hint is just suppressed where it would
+          mislead. Initial render is hasHover=false (SSR-safe), so
+          server output never claims an H key; the hint fades in
+          after hydration on capable devices. */}
+      {hasHover && (
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 2, duration: 0.6 }}
+          className="absolute bottom-6 left-1/2 -translate-x-1/2 text-[10px] uppercase tracking-[0.3em] text-foreground/25"
+        >
+          Press H to go home
+        </motion.p>
+      )}
+    </main>
+  );
+}

--- a/src/components/not-found/ReturnPortal.jsx
+++ b/src/components/not-found/ReturnPortal.jsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Home } from 'lucide-react';
+import Link from 'next/link';
+
+/**
+ * Animated CTA back to the homepage. Reads as a "portal" — the
+ * outer pulsing ring (framer-motion) creates a charging effect
+ * and on hover the neon border thickens, the background warms,
+ * and the home icon nudges left as a directional cue.
+ *
+ * The entrance delay (1.2s) is intentionally last in the page's
+ * staggered reveal — 404 → subtitles → button — so the button
+ * appears once the user has had a moment to read the void.
+ */
+export default function ReturnPortal() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 1.2, duration: 0.5 }}
+      className="relative inline-block"
+    >
+      <Link
+        href="/"
+        prefetch={false}
+        className="group relative inline-flex items-center gap-3 rounded-full border border-[#ff6d05]/50 bg-black/60 px-8 py-4 font-mono text-sm tracking-wider text-ember-halo transition-all duration-300 hover:border-[#ff6d05] hover:bg-[#ff6d05]/10 hover:shadow-[0_0_30px_#ff6d0540,0_0_60px_#ff6d0520] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff6d05] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+      >
+        <Home
+          className="h-4 w-4 transition-transform group-hover:-translate-x-1"
+          strokeWidth={1.5}
+          aria-hidden="true"
+        />
+        TAKE ME BACK
+        {/* The pulsing ring is purely decorative. It sits on top of
+            the link but is pointer-events:none so clicks/taps fall
+            through to the Link underneath. */}
+        <motion.span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 rounded-full border border-[#ff6d05]/20"
+          animate={{ scale: [1, 1.08, 1], opacity: [0.3, 0, 0.3] }}
+          transition={{ duration: 2.5, repeat: Infinity, ease: 'easeInOut' }}
+        />
+      </Link>
+    </motion.div>
+  );
+}

--- a/src/components/not-found/ReturnPortal.jsx
+++ b/src/components/not-found/ReturnPortal.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Home } from 'lucide-react';
 import Link from 'next/link';
 
@@ -13,13 +13,31 @@ import Link from 'next/link';
  * The entrance delay (1.2s) is intentionally last in the page's
  * staggered reveal — 404 → subtitles → button — so the button
  * appears once the user has had a moment to read the void.
+ *
+ * Reduced-motion users:
+ *   • Entrance: skip the slide/scale, button just appears (the
+ *     stagger across the rest of the page still reads, since it
+ *     uses delays via CSS transitions on opacity which are
+ *     reduced-motion-safe per Motion's a11y guidance).
+ *   • Pulsing ring: replaced with a static ring at low opacity
+ *     so the "portal" visual hint remains, but no infinite
+ *     transform/opacity oscillation runs.
  */
 export default function ReturnPortal() {
+  const prefersReducedMotion = useReducedMotion();
+
   return (
     <motion.div
-      initial={{ opacity: 0, y: 30 }}
+      // `initial={false}` makes framer render in the animate state
+      // with no transition — clean way to skip the entrance for
+      // reduced-motion users without losing the spec.
+      initial={prefersReducedMotion ? false : { opacity: 0, y: 30 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: 1.2, duration: 0.5 }}
+      transition={
+        prefersReducedMotion
+          ? { duration: 0 }
+          : { delay: 1.2, duration: 0.5 }
+      }
       className="relative inline-block"
     >
       <Link
@@ -39,8 +57,16 @@ export default function ReturnPortal() {
         <motion.span
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 rounded-full border border-[#ff6d05]/20"
-          animate={{ scale: [1, 1.08, 1], opacity: [0.3, 0, 0.3] }}
-          transition={{ duration: 2.5, repeat: Infinity, ease: 'easeInOut' }}
+          animate={
+            prefersReducedMotion
+              ? { scale: 1, opacity: 0.25 }
+              : { scale: [1, 1.08, 1], opacity: [0.3, 0, 0.3] }
+          }
+          transition={
+            prefersReducedMotion
+              ? { duration: 0 }
+              : { duration: 2.5, repeat: Infinity, ease: 'easeInOut' }
+          }
         />
       </Link>
     </motion.div>


### PR DESCRIPTION
This pull request implements a fully custom immersive 404 (Not Found) page for the site, replacing the previous external portfolio link with an unmatched route that triggers the new void-themed 404 experience. The update introduces a visually distinctive "404" screen with animated glitch effects, amethyst firefly particles, and strong brand styling, all while maintaining accessibility and respecting reduced-motion preferences.

The most important changes are:

**404 Page Implementation:**

* Added a new server component `src/app/not-found.js` that sets the 404 page's metadata and renders the interactive client component `NotFoundClient`.
* Updated the "My Past" link in `src/app/data.js` to route to `/my-past`, intentionally triggering the custom 404 page until a real "My Past" page is created.

**Visual & Interactive Effects:**

* Introduced extensive CSS in `src/app/globals.css` to style the 404 page with a radial-vignette void background, glitch-animated "404" headline, and amethyst firefly orbs. The CSS includes keyframes, accessibility fallbacks, and brand-consistent styling.
* Added `src/components/not-found/GlitchText.jsx`, a client component that renders the "404" headline with continuous chromatic aberration and periodic animated scrambling, with accessibility and reduced-motion support.
* Added `src/components/not-found/FloatingParticles.jsx`, a client component that generates and animates a field of amethyst and ember-tinted firefly orbs, visually tying the 404 page to the site's ambient theme.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom 404 page with animated glitch headline, particle orbs, and reduced-motion support
  * Animated "return home" button with subtle pulsing and keyboard shortcuts (H/Escape) for quick navigation
  * Improved 404 accessibility and motion handling (ARIA, parallax gated by device/motion)

* **Bug Fixes**
  * Missing project IDs now produce a proper 404 response
  * "My Past" link routed internally to surface the site's custom 404 page

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MA1002643/theabdullahfolio/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->