### PR TITLE
feat: adjust Home button size and tooltip styling for improved responsiveness

### DIFF
--- a/src/components/HomeBtn.jsx
+++ b/src/components/HomeBtn.jsx
@@ -17,13 +17,13 @@ const HomeBtn = () => {
         prefetch={false}
         className='text-foreground rounded-full flex items-center justify-center custom-bg touch-manipulation pointer-events-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff6d05]'
       >
-        <span className='relative w-14 h-14 p-4 group'>
+        <span className='relative w-10 h-10 p-2 sm:w-12 sm:h-12 sm:p-3 md:w-14 md:h-14 md:p-4 group'>
           <Home
             className='w-full h-auto text-white group-hover:text-[#ff6d05] transition-all duration-300'
             strokeWidth={1.5}
           />
           <span className='desktop-hover-only peer bg-transparent absolute top-0 left-0 w-full h-full' />
-          <span className='desktop-hover-only absolute hidden peer-hover:block px-2 py-1 left-full mx-2 top-1/2 -translate-y-1/2 bg-background text-[#ff6d05] text-sm rounded-md shadow-lg whitespace-nowrap'>
+          <span className='desktop-hover-only absolute hidden peer-hover:block px-2 py-1 sm:px-2.5 sm:py-1.5 left-full mx-2 md:mx-3 top-1/2 -translate-y-1/2 bg-background text-[#ff6d05] text-xs sm:text-sm md:text-base rounded-md shadow-lg whitespace-nowrap'>
             Home
           </span>
         </span>

--- a/src/components/HomeBtn.jsx
+++ b/src/components/HomeBtn.jsx
@@ -17,13 +17,13 @@ const HomeBtn = () => {
         prefetch={false}
         className='text-foreground rounded-full flex items-center justify-center custom-bg touch-manipulation pointer-events-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff6d05]'
       >
-        <span className='relative w-10 h-10 p-2 sm:w-12 sm:h-12 sm:p-3 md:w-14 md:h-14 md:p-4 group'>
+        <span className='relative w-11 h-11 p-2.5 sm:w-12 sm:h-12 sm:p-3 md:w-14 md:h-14 md:p-4 group'>
           <Home
             className='w-full h-auto text-white group-hover:text-[#ff6d05] transition-all duration-300'
             strokeWidth={1.5}
           />
           <span className='desktop-hover-only peer bg-transparent absolute top-0 left-0 w-full h-full' />
-          <span className='desktop-hover-only absolute hidden peer-hover:block px-2 py-1 sm:px-2.5 sm:py-1.5 left-full mx-2 md:mx-3 top-1/2 -translate-y-1/2 bg-background text-[#ff6d05] text-xs sm:text-sm md:text-base rounded-md shadow-lg whitespace-nowrap'>
+          <span className='desktop-hover-only absolute hidden peer-hover:block px-2 py-1 sm:px-2.5 sm:py-1.5 left-full ml-2 md:ml-3 top-1/2 -translate-y-1/2 bg-background text-[#ff6d05] text-xs sm:text-sm md:text-base rounded-md shadow-lg whitespace-nowrap'>
             Home
           </span>
         </span>


### PR DESCRIPTION
This pull request updates the `HomeBtn` component to improve its responsiveness and accessibility. The main changes involve adjusting the button and its tooltip sizes and spacing to better support different screen sizes.

**Responsive design improvements:**

* Updated the button's inner `span` (`w-14 h-14 p-4`) to use responsive sizing and padding classes for better appearance across screen sizes (`w-11 h-11 p-2.5 sm:w-12 sm:h-12 sm:p-3 md:w-14 md:h-14 md:p-4`). Base size is **44 × 44 CSS px** so the tap target meets WCAG 2.5.5 / Apple HIG minimums on mobile; padding scales so the inner icon stays a consistent 24 × 24 px across all breakpoints.
* Adjusted the tooltip's padding, margin, and font size to scale appropriately with device size, improving readability and layout (`px-2 py-1` → `px-2 py-1 sm:px-2.5 sm:py-1.5`, `mx-2` → `ml-2 md:ml-3`, `text-sm` → `text-xs sm:text-sm md:text-base`). Switched from `mx-*` to `ml-*` since the tooltip is absolutely positioned with `left-full` and only the left margin contributes to spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the home button's responsive design with improved layout scaling and padding that better adapts across mobile, tablet, and desktop breakpoints. Refined the associated hover tooltip with optimized positioning, responsive font sizing adjustments, and adaptive spacing to ensure improved visibility, readability, and overall user experience on all device screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MA1002643/theabdullahfolio/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->