### PR TITLE
feat: integrate GitHub stats API with caching and fallback mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,33 @@ RECEIVER_EMAIL=recipient@example.com
 # ABSTRACT_API_KEY=...            # email reputation check via abstractapi.com
 ```
 
+### GitHub Stats Integration
+
+The `/about` page (Most Used Languages, GitHub Stats, Streaks, Repository card) is powered by `/api/github-stats`, a single GraphQL aggregator that runs against your own PAT instead of public unauthenticated requests.
+
+**1. Create the token** — [github.com/settings/tokens](https://github.com/settings/tokens). Either:
+- **Fine-grained PAT** (recommended) scoped to your account with *read-only* access to `Public repositories` (Metadata) and `Contents`.
+- **Classic PAT** with the `public_repo` scope.
+
+Set it as `GITHUB_TOKEN` in `.env.local`. The token is server-only — it is never exposed to the browser bundle (no `NEXT_PUBLIC_` prefix).
+
+**2. Caching behavior** — three layers protect the GitHub API from being hit on every request:
+
+| Layer | TTL | Where |
+|---|---|---|
+| Next.js Data Cache (`unstable_cache`) | 10 min | Survives serverless cold starts within a deployment |
+| CDN `s-maxage` / `stale-while-revalidate` / `stale-if-error` | 10 min / 5 min / 24 hr | Edge caches the response and serves stale on upstream errors |
+| `localStorage` last-good payload | until next successful fetch | Hydrates the stat cards on cold page loads so they never render empty |
+
+**3. Fallback on total failure** — if GitHub returns errors, the route serves the bundled snapshot at [src/data/github-stats-fallback.json](src/data/github-stats-fallback.json) with `X-Cache-Status: FALLBACK`. To refresh the snapshot, run the dev server, hit the API, and overwrite the file:
+
+```bash
+curl "http://localhost:3000/api/github-stats?username=YOUR_USERNAME&repo=YOUR_REPO" \
+  | python3 -m json.tool > src/data/github-stats-fallback.json
+```
+
+**4. Cache invalidation** — the Data Cache expires automatically every 10 minutes. To force a refresh sooner, redeploy or call `revalidateTag("github-stats")` from a Server Action.
+
 ### Commands
 
 ```bash
@@ -321,7 +348,7 @@ upgrade-insecure-requests
 | **Image pipeline** | Sharp — automatic WebP / AVIF conversion |
 | **Font loading** | `next/font` self-hosted Inter, zero layout shift |
 | **Code splitting** | Route-based automatic splitting; Three.js loaded only on `/projects/[id]` |
-| **API caching** | 10-min in-memory cache on `/api/github-stats` to reduce GitHub API round trips |
+| **API caching** | `/api/github-stats` wrapped in Next.js `unstable_cache` (10-min TTL, 5-min stale-while-revalidate, 24-hr stale-if-error) — persists across serverless cold starts and falls back to a bundled JSON snapshot on total upstream failure |
 | **Analytics** | Vercel Speed Insights + Web Analytics for real-user Core Web Vitals |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ theabdullahfolio/
 
 - **Node.js** ≥ 18.17
 - **npm** / **yarn** / **pnpm**
-- A [GitHub Personal Access Token](https://github.com/settings/tokens) with `read:user` and `read:org` scopes
+- A [GitHub Personal Access Token](https://github.com/settings/tokens) — see [GitHub Stats Integration](#github-stats-integration) below for the exact scopes required
 - SMTP credentials — Gmail [App Password](https://support.google.com/accounts/answer/185833) recommended
 
 ### Installation

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -43,6 +43,16 @@ export async function GET(request) {
     );
   }
 
+  // `repoName` feeds a `String!` GraphQL variable; missing it would throw
+  // inside the cached fetcher and incorrectly trip the fallback branch below,
+  // so reject the malformed request up front.
+  if (!repoName) {
+    return NextResponse.json(
+      { error: "Missing 'repo' query parameter." },
+      { status: 400 }
+    );
+  }
+
   try {
     const data = await getCachedGithubStats(username, repoName);
     return NextResponse.json(data, { headers: CACHE_HEADERS });

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -1,39 +1,37 @@
 import { parseGitHubText } from "@/utils/emoji";
 import { calculateRank } from "@/utils/rankCalculator";
+import { unstable_cache } from "next/cache";
 import { NextResponse } from "next/server";
+import fallbackStats from "@/data/github-stats-fallback.json";
 
 const GITHUB_API = "https://api.github.com/graphql";
-const TOKEN = process.env.GITHUB_TOKEN; // store this securely in your .env.local
+const TOKEN = process.env.GITHUB_TOKEN;
+const REVALIDATE_SECONDS = 10 * 60;
 
-// ===== IN-MEMORY CACHE =====
-const cache = new Map();
-const CACHE_DURATION = 10 * 60 * 1000; // 10 minutes in milliseconds
+// Aggregated GitHub fetcher wrapped in Next's persistent data cache. The
+// per-(username, repoName) cache key is derived from the runtime args; cached
+// payloads survive serverless cold starts within a deployment, so each cold
+// start no longer costs a fresh round of GraphQL calls.
+const getCachedGithubStats = unstable_cache(
+  async (username, repoName) => {
+    const [languages, stats, icons] = await Promise.all([
+      getAllLanguages(username),
+      fetchGitHubStats(username, repoName),
+      getUserLanguages(username),
+    ]);
+    return {
+      languages: languages.slice(0, 6),
+      stats,
+      icons,
+    };
+  },
+  ["github-stats"],
+  { revalidate: REVALIDATE_SECONDS, tags: ["github-stats"] }
+);
 
-function getCachedData(key) {
-  const cached = cache.get(key);
-  if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
-    console.log(`Cache HIT for key: ${key}`);
-    return cached.data;
-  }
-  console.log(`Cache MISS for key: ${key}`);
-  return null;
-}
-
-function setCachedData(key, data) {
-  cache.set(key, { data, timestamp: Date.now() });
-  console.log(`Cache SET for key: ${key}`);
-}
-
-// Cleanup old cache entries every 15 minutes
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, value] of cache.entries()) {
-    if (now - value.timestamp > CACHE_DURATION) {
-      cache.delete(key);
-      console.log(`Cache EXPIRED and removed: ${key}`);
-    }
-  }
-}, 15 * 60 * 1000);
+const CACHE_HEADERS = {
+  "Cache-Control": `public, s-maxage=${REVALIDATE_SECONDS}, stale-while-revalidate=300, stale-if-error=86400`,
+};
 
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
@@ -47,45 +45,21 @@ export async function GET(request) {
     );
   }
 
-  // Create unique cache key
-  const cacheKey = `${username}-${repoName || 'default'}`;
-  
-  // Check cache first
-  const cachedData = getCachedData(cacheKey);
-  if (cachedData) {
-    return NextResponse.json(cachedData, {
-      headers: {
-        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=300',
-        'X-Cache-Status': 'HIT',
-      },
-    });
-  }
-
   try {
-    const languages = await getAllLanguages(username);
-    const stats = await fetchGitHubStats(username, repoName);
-    const iconsLanguages = await getUserLanguages(username);
-    
-    const responseData = { 
-      languages: languages.slice(0, 6), 
-      stats, 
-      icons: iconsLanguages 
-    };
-    
-    // Store in cache
-    setCachedData(cacheKey, responseData);
-    
-    return NextResponse.json(responseData, {
-      headers: {
-        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=300',
-        'X-Cache-Status': 'MISS',
-      },
-    });
+    const data = await getCachedGithubStats(username, repoName);
+    return NextResponse.json(data, { headers: CACHE_HEADERS });
   } catch (error) {
-    console.error("GitHub API Error:", error);
+    // Total upstream failure (rate limit, network, GraphQL error). Serve the
+    // bundled snapshot so the about page never renders empty stat cards.
+    console.error("GitHub stats fetch failed, serving fallback:", error);
     return NextResponse.json(
-      { error: "Failed to fetch GitHub language stats" },
-      { status: 500 }
+      { ...fallbackStats, _fallback: true },
+      {
+        headers: {
+          ...CACHE_HEADERS,
+          "X-Cache-Status": "FALLBACK",
+        },
+      }
     );
   }
 }

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -14,15 +14,13 @@ const REVALIDATE_SECONDS = 10 * 60;
 // start no longer costs a fresh round of GraphQL calls.
 const getCachedGithubStats = unstable_cache(
   async (username, repoName) => {
-    const [languages, stats, icons] = await Promise.all([
+    const [languages, stats] = await Promise.all([
       getAllLanguages(username),
       fetchGitHubStats(username, repoName),
-      getUserLanguages(username),
     ]);
     return {
       languages: languages.slice(0, 6),
       stats,
-      icons,
     };
   },
   ["github-stats"],
@@ -337,46 +335,3 @@ function computeStreaks(contributionCalendar) {
   return { currentStreak, longestStreak };
 }
 
-async function getUserLanguages(username) {
-  if (!username) throw new Error("Username is required");
-
-  const allLanguages = new Set();
-  let page = 1;
-
-  try {
-    while (true) {
-      // Fetch up to 100 repos per page
-      const repoRes = await fetch(
-        `https://api.github.com/users/${username}/repos?per_page=100&page=${page}`,
-        {
-          headers: {
-            Accept: "application/vnd.github.v3+json",
-            // Optionally add a GitHub token if hitting rate limits:
-            // Authorization: `token YOUR_GITHUB_TOKEN`,
-          },
-        }
-      );
-
-      if (!repoRes.ok) throw new Error(`GitHub API error: ${repoRes.statusText}`);
-      const repos = await repoRes.json();
-      if (repos.length === 0) break; // no more repos
-
-      // Get language data for each repo
-      const langRequests = repos.map(async (repo) => {
-        const langRes = await fetch(repo.languages_url);
-        if (langRes.ok) {
-          const langs = await langRes.json();
-          Object.keys(langs).forEach((lang) => allLanguages.add(lang));
-        }
-      });
-
-      await Promise.all(langRequests);
-      page++;
-    }
-
-    return Array.from(allLanguages).sort();
-  } catch (err) {
-    console.error("Error fetching languages:", err);
-    return [];
-  }
-}

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -8,6 +8,8 @@ import StreakStatsCard from "./StreakStatsCard";
 import ReadmeStatsCard from "./RepoStatsCard";
 import { detectChanges } from "@/utils/diffChanges";
 
+const GITHUB_STATS_STORAGE_KEY = "ma1002643:github-stats:lastGood";
+
 const ARCHITECT_PARAGRAPH = "My journey in web development is powered by an array of mystical tools and languages, with JavaScript casting the core of my enchantments. I wield frameworks like React.js and Next.js with precision, crafting seamless portals (websites) that connect realms (users) across the digital universe. The ancient arts of the Jamstack empower me to create fast, secure, and dynamic experiences, while my design skills ensure every creation is not only functional but visually captivating. Join me as I continue to explore new spells and technologies to shape the future of the web.";
 const ARCHITECT_WORDS = ARCHITECT_PARAGRAPH.split(" ");
 
@@ -144,8 +146,17 @@ const AboutDetails = () => {
 
 
   const getGithubStats = async () => {
-    const res = await fetch(`/api/github-stats?username=${username}&repo=${repo}`);
-    const data = await res.json();
+    let data;
+    try {
+      const res = await fetch(`/api/github-stats?username=${username}&repo=${repo}`);
+      if (!res.ok) throw new Error(`github-stats API responded ${res.status}`);
+      data = await res.json();
+    } catch (err) {
+      // Keep whatever state we already have (localStorage hydrate or prior poll)
+      // so the cards never go blank on a transient fetch failure.
+      console.error("Failed to load GitHub stats:", err);
+      return;
+    }
 
     setGithubStats(prevStats => {
       // First-time load
@@ -190,16 +201,37 @@ const AboutDetails = () => {
 
       return updatedStats;
     });
+
+    // Persist the last good payload so the next page load can hydrate
+    // immediately from cache while the fresh fetch runs in the background.
+    try {
+      window.localStorage.setItem(
+        GITHUB_STATS_STORAGE_KEY,
+        JSON.stringify({
+          languages: data.languages || [],
+          stats: data.stats || { user: {}, stats: {}, streaks: {}, repo: {} },
+        })
+      );
+    } catch {
+      // Quota exceeded or private mode — non-fatal.
+    }
   };
 
   useEffect(() => {
+    // Hydrate from the previously cached payload so the stat cards never
+    // render empty on a cold page load.
+    try {
+      const cached = window.localStorage.getItem(GITHUB_STATS_STORAGE_KEY);
+      if (cached) setGithubStats(JSON.parse(cached));
+    } catch {
+      // Ignore parse / access errors — the fresh fetch will populate state.
+    }
+
     getGithubStats();
 
-    // Fetch every 5 minutes instead of 8 seconds to respect cache and rate limits
-    const interval = setInterval(() => {
-      getGithubStats();
-    }, 5 * 60 * 1000); // 5 minutes = 300,000ms
-
+    // Poll every 10 minutes to match the API cache TTL (no point asking for
+    // fresh data more often than the server is willing to compute it).
+    const interval = setInterval(getGithubStats, 10 * 60 * 1000);
     return () => clearInterval(interval);
   }, []);
 

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -160,6 +160,13 @@ const AboutDetails = () => {
     }
 
     setGithubStats(prevStats => {
+      // If the API served the bundled fallback (upstream failure) and we
+      // already have real data on screen, keep that state — only let the
+      // fallback populate on a truly empty first load.
+      if (data._fallback && prevStats) {
+        return prevStats;
+      }
+
       // First-time load
       if (!prevStats) {
         return {

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -8,7 +8,8 @@ import StreakStatsCard from "./StreakStatsCard";
 import ReadmeStatsCard from "./RepoStatsCard";
 import { detectChanges } from "@/utils/diffChanges";
 
-const GITHUB_STATS_STORAGE_KEY = "ma1002643:github-stats:lastGood";
+const githubStatsStorageKey = (username, repo) =>
+  `github-stats:lastGood:${username}:${repo}`;
 
 const ARCHITECT_PARAGRAPH = "My journey in web development is powered by an array of mystical tools and languages, with JavaScript casting the core of my enchantments. I wield frameworks like React.js and Next.js with precision, crafting seamless portals (websites) that connect realms (users) across the digital universe. The ancient arts of the Jamstack empower me to create fast, secure, and dynamic experiences, while my design skills ensure every creation is not only functional but visually captivating. Join me as I continue to explore new spells and technologies to shape the future of the web.";
 const ARCHITECT_WORDS = ARCHITECT_PARAGRAPH.split(" ");
@@ -204,16 +205,21 @@ const AboutDetails = () => {
 
     // Persist the last good payload so the next page load can hydrate
     // immediately from cache while the fresh fetch runs in the background.
-    try {
-      window.localStorage.setItem(
-        GITHUB_STATS_STORAGE_KEY,
-        JSON.stringify({
-          languages: data.languages || [],
-          stats: data.stats || { user: {}, stats: {}, streaks: {}, repo: {} },
-        })
-      );
-    } catch {
-      // Quota exceeded or private mode — non-fatal.
+    // Skip when the API served the bundled fallback (`_fallback: true`),
+    // otherwise a transient upstream failure would overwrite genuine cached
+    // stats with stale snapshot data for every future cold load.
+    if (!data?._fallback) {
+      try {
+        window.localStorage.setItem(
+          githubStatsStorageKey(username, repo),
+          JSON.stringify({
+            languages: data.languages || [],
+            stats: data.stats || { user: {}, stats: {}, streaks: {}, repo: {} },
+          })
+        );
+      } catch {
+        // Quota exceeded or private mode — non-fatal.
+      }
     }
   };
 
@@ -221,7 +227,7 @@ const AboutDetails = () => {
     // Hydrate from the previously cached payload so the stat cards never
     // render empty on a cold page load.
     try {
-      const cached = window.localStorage.getItem(GITHUB_STATS_STORAGE_KEY);
+      const cached = window.localStorage.getItem(githubStatsStorageKey(username, repo));
       if (cached) setGithubStats(JSON.parse(cached));
     } catch {
       // Ignore parse / access errors — the fresh fetch will populate state.

--- a/src/data/github-stats-fallback.json
+++ b/src/data/github-stats-fallback.json
@@ -1,0 +1,90 @@
+{
+    "languages": [
+        {
+            "language": "JavaScript",
+            "color": "#f1e05a",
+            "size": 480017,
+            "percentage": "57.18"
+        },
+        {
+            "language": "CSS",
+            "color": "#663399",
+            "size": 179934,
+            "percentage": "21.44"
+        },
+        {
+            "language": "HTML",
+            "color": "#e34c26",
+            "size": 117506,
+            "percentage": "14.00"
+        },
+        {
+            "language": "Vue",
+            "color": "#41b883",
+            "size": 58670,
+            "percentage": "6.99"
+        },
+        {
+            "language": "TypeScript",
+            "color": "#3178c6",
+            "size": 2785,
+            "percentage": "0.33"
+        },
+        {
+            "language": "Dockerfile",
+            "color": "#384d54",
+            "size": 500,
+            "percentage": "0.06"
+        }
+    ],
+    "stats": {
+        "user": {
+            "username": "MA1002643",
+            "name": "Muhammad Abdullah",
+            "createdAt": "Jul 23, 2021"
+        },
+        "stats": {
+            "commits": 1495,
+            "prs": 29,
+            "issues": 232,
+            "contributedTo": 10,
+            "followers": 6,
+            "stars": 1,
+            "totalContributions": 1800,
+            "level": "B-",
+            "percentile": "65.19"
+        },
+        "streaks": {
+            "totalContributions": {
+                "value": 250,
+                "dateRange": "May 18, 2025 - Present"
+            },
+            "currentStreak": {
+                "value": 252,
+                "dateRange": "Sep 12, 2025 - Present"
+            },
+            "longestStreak": {
+                "value": 252,
+                "dateRange": "Sep 12, 2025 - Present"
+            }
+        },
+        "repo": {
+            "title": "github-readme-stats",
+            "description": "\u26a1 Dynamically generated stats for your github readmes",
+            "language": "JavaScript",
+            "color": "#f1e05a",
+            "stars": 0
+        }
+    },
+    "icons": [
+        "CSS",
+        "Dockerfile",
+        "HTML",
+        "JavaScript",
+        "PHP",
+        "Procfile",
+        "Shell",
+        "TypeScript",
+        "Vue"
+    ]
+}

--- a/src/data/github-stats-fallback.json
+++ b/src/data/github-stats-fallback.json
@@ -75,16 +75,5 @@
             "color": "#f1e05a",
             "stars": 0
         }
-    },
-    "icons": [
-        "CSS",
-        "Dockerfile",
-        "HTML",
-        "JavaScript",
-        "PHP",
-        "Procfile",
-        "Shell",
-        "TypeScript",
-        "Vue"
-    ]
+    }
 }


### PR DESCRIPTION
This pull request significantly improves the GitHub stats integration for the `/about` page by replacing the previous in-memory cache with a robust, multi-layered caching strategy. It introduces persistent caching at the API and client levels, ensures graceful fallback on upstream failures, and updates documentation to reflect these changes.

**API and Caching Improvements:**

* Replaced the in-memory cache in `src/app/api/github-stats/route.js` with Next.js's `unstable_cache`, providing a persistent, per-user cache that survives serverless cold starts and enables cache invalidation via tags. The API now also sets detailed cache control headers for CDN and edge caching.
* On total upstream failure (e.g., GitHub API rate limits), the API now serves a bundled fallback snapshot from `src/data/github-stats-fallback.json`, ensuring the `/about` page never renders empty stat cards. [[1]](diffhunk://#diff-54a0dcd85392a4f0a2cc54f7c0d17d6fe40b27a7045637ddb270306de822cb90L50-R62) [[2]](diffhunk://#diff-8a38bbb3cd1b6a750e0f063d2c846e47161598e0059f040dc7bb53f8606b6938R1-R90)

**Client-Side Resilience and Performance:**

* The `/about` page component (`src/components/about/index.jsx`) now hydrates GitHub stats from `localStorage` on cold page loads, ensuring immediate display of the last good payload while fresh data is fetched in the background. It also persists successful fetches back to `localStorage` for future loads. [[1]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R11-R12) [[2]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R149-R159) [[3]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R204-R234)

**Documentation Updates:**

* Updated the `README.md` to document the new GitHub stats caching architecture, including setup instructions for the required GitHub token, cache layers, fallback mechanism, and cache invalidation strategies. The feature table now reflects the new multi-layered caching and fallback behaviour. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R281-R307) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L324-R351)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side caching for GitHub stats with automatic revalidation and a bundled fallback payload on upstream failure.
  * GitHub stats now persist locally for offline availability and faster hydration.

* **Bug Fixes**
  * Graceful error handling: failed fetches no longer clear existing stats in the UI.

* **Documentation**
  * Updated setup guide with GitHub Stats Integration and caching/refresh guidance.

* **Performance**
  * Increased stats refresh interval (5 → 10 minutes) to reduce API requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MA1002643/theabdullahfolio/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->