### PR TITLE
feat: add ExperienceUpdateBanner and UpdateBanner components for experience Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['18', '20']
+        # Node 18 went EOL in April 2025, and a direct dep (`pdf-parse@^2.4.5`)
+        # requires `>=20.16.0 <21 || >=22.3.0`, so a Node 18 job would fail
+        # on install. Node 22 is the current LTS; 20 stays for the older-LTS
+        # smoke test until that line also goes EOL.
+        node-version: ['20', '22']
 
     steps:
       - name: Checkout repository

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Refuse to install when the active Node version doesn't satisfy the
+# `engines.node` range in package.json. Without this, npm only emits a
+# warning on a mismatch — a contributor on EOL Node 18 would silently
+# get a broken install (e.g. pdf-parse refuses to load) instead of a
+# clear, immediate error.
+engine-strict=true

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // `pdf-parse` (used by /api/experience-summary) depends on `pdfjs-dist`,
+  // an ESM bundle that touches browser-style globals (Object.defineProperty
+  // on `globalThis`, etc.) that Next's RSC webpack pass mangles. Marking
+  // it external tells Next to leave it alone and `require()` it at
+  // runtime from node_modules, which is exactly what server functions
+  // already do for native modules. Without this the route throws
+  // `Object.defineProperty called on non-object` at import time.
+  experimental: {
+    serverComponentsExternalPackages: ["pdf-parse"],
+  },
   async headers() {
     return [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lucide-react": "^0.344.0",
         "next": "^14.2.30",
         "nodemailer": "^7.0.10",
+        "pdf-parse": "^2.4.5",
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.61.1",
@@ -788,6 +789,190 @@
       },
       "peerDependencies": {
         "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5543,6 +5728,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "nextjs-creative-portfolio-starter-code-files",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20.16.0 <21 || >=22.3.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lucide-react": "^0.344.0",
     "next": "^14.2.30",
     "nodemailer": "^7.0.10",
+    "pdf-parse": "^2.4.5",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.61.1",

--- a/src/app/api/experience-summary/route.js
+++ b/src/app/api/experience-summary/route.js
@@ -42,8 +42,22 @@ const RESPONSE_CACHE_HEADERS = {
 
 const GITHUB_API = "https://api.github.com/graphql";
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+// Per-call ceiling. Must stay strictly below the serverless function
+// timeout (10 s on Hobby, 60 s on Pro). Same env var as `/api/github-stats`
+// so a single override raises both routes for Pro/Enterprise.
 const GITHUB_TIMEOUT_MS =
   Number(process.env.GITHUB_TIMEOUT_MS) || 8000;
+// Cumulative wall-clock budget across the entire owned-repos pagination.
+// Per-call timeouts alone aren't enough: with `MAX_OWNED_REPO_PAGES = 10`
+// and an 8 s per-call ceiling, the theoretical worst case is 80 s — well
+// past Hobby's 10 s function limit. This bound is the hard upper limit on
+// time spent paginating; if it fires we return whatever repos we managed
+// to collect (partial) rather than throw, so the modal still gets the
+// newest entries. Default 9 s keeps the function well under Hobby's
+// 10 s budget even on a cold miss. Same env var name as `/api/github-stats`
+// so a Pro/Enterprise override raises both routes together.
+const GITHUB_OVERALL_BUDGET_MS =
+  Number(process.env.GITHUB_OVERALL_BUDGET_MS) || 9000;
 
 // Restrict by username for the same reason `/api/github-stats` does —
 // without an allowlist, any caller varying `?username=` would trigger a
@@ -95,14 +109,27 @@ function buildFingerprint(payload) {
 
 // Single-call GraphQL wrapper used by the owned-repos pagination loop.
 // Each call gets its own AbortController + timeout so a stalled fetch
-// can't hold the serverless function past its budget. Extracted so the
-// loop body stays focused on pagination logic.
-async function githubGraphQL(query, variables) {
+// can't hold the serverless function past its budget. The paginating
+// caller threads a per-call ceiling derived from its remaining wall-
+// clock budget so a single slow GitHub response can't consume the
+// entire `GITHUB_OVERALL_BUDGET_MS` on the first page.
+async function githubGraphQL(query, variables, timeoutMs = GITHUB_TIMEOUT_MS) {
   if (!GITHUB_TOKEN) {
     throw new Error("GITHUB_TOKEN not set");
   }
+  // Short-circuit when the budget is already exhausted. `setTimeout(..., 0)`
+  // queues the abort as a macrotask, so without this we'd still kick off
+  // a fetch that opens a TCP/TLS connection before the immediate abort
+  // fires. AbortError name matches the shape `fetch` produces, so the
+  // pagination loop's existing AbortError catch handles it uniformly.
+  if (timeoutMs <= 0) {
+    throw new DOMException(
+      "experience-summary: GitHub call budget exhausted",
+      "AbortError",
+    );
+  }
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), GITHUB_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetch(GITHUB_API, {
       method: "POST",
@@ -131,8 +158,18 @@ async function githubGraphQL(query, variables) {
 // / member repos; `isFork: false` excludes forks (those weren't created
 // by this account). Returns `{ name, createdAt, url }` records in DESC
 // order so the modal can render newest-first; the earliest createdAt is
-// always the last element. Bounded by MAX_OWNED_REPO_PAGES so a malformed
-// pageInfo can't infinite-loop.
+// always the last element.
+//
+// Two safety nets:
+//   - `MAX_OWNED_REPO_PAGES` — hard page ceiling so a malformed
+//     `pageInfo` can't infinite-loop.
+//   - `GITHUB_OVERALL_BUDGET_MS` — wall-clock budget. Each call's
+//     per-call timeout is capped at `min(GITHUB_TIMEOUT_MS, remaining
+//     budget)`, and if the budget is exhausted between pages we break
+//     and return whatever was collected. Partial results are far
+//     better than a thrown error: the catch in `buildExperienceSummary`
+//     would drop the entire personal-projects panel, and the 10-min
+//     `unstable_cache` would lock that state in until the next TTL.
 async function fetchOwnedRepos(username) {
   const query = `
     query OwnedRepos($username: String!, $after: String) {
@@ -155,22 +192,53 @@ async function fetchOwnedRepos(username) {
       }
     }
   `;
+  const deadline = Date.now() + GITHUB_OVERALL_BUDGET_MS;
   const repos = [];
   let cursor = null;
   for (let page = 0; page < MAX_OWNED_REPO_PAGES; page++) {
-    const data = await githubGraphQL(query, { username, after: cursor });
-    const conn = data?.user?.repositories;
-    if (!conn) break;
-    for (const node of conn.nodes ?? []) {
-      if (!node?.name || !node?.createdAt) continue;
-      repos.push({
-        name: node.name,
-        createdAt: node.createdAt,
-        url: node.url ?? null,
-      });
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      console.warn(
+        `experience-summary: wall-clock budget exhausted after page ${page} ` +
+          `(${repos.length} repos collected) — returning partial result`,
+      );
+      break;
     }
-    if (!conn.pageInfo?.hasNextPage) break;
-    cursor = conn.pageInfo.endCursor;
+    // Cap per-call timeout at the remaining budget so a single slow
+    // call can't push the loop past the overall deadline.
+    const perCallTimeout = Math.min(GITHUB_TIMEOUT_MS, remaining);
+    try {
+      const data = await githubGraphQL(
+        query,
+        { username, after: cursor },
+        perCallTimeout,
+      );
+      const conn = data?.user?.repositories;
+      if (!conn) break;
+      for (const node of conn.nodes ?? []) {
+        if (!node?.name || !node?.createdAt) continue;
+        repos.push({
+          name: node.name,
+          createdAt: node.createdAt,
+          url: node.url ?? null,
+        });
+      }
+      if (!conn.pageInfo?.hasNextPage) break;
+      cursor = conn.pageInfo.endCursor;
+    } catch (err) {
+      // Timeout / abort mid-pagination — keep what we have, log, and
+      // exit. Any other error (auth, GraphQL field error) is fatal and
+      // bubbles up so the outer `Promise.allSettled` can flag the
+      // GitHub side as failed.
+      if (err?.name === "AbortError" && repos.length > 0) {
+        console.warn(
+          `experience-summary: page ${page} aborted (timeout) — ` +
+            `returning ${repos.length} repos collected so far`,
+        );
+        break;
+      }
+      throw err;
+    }
   }
   return repos;
 }

--- a/src/app/api/experience-summary/route.js
+++ b/src/app/api/experience-summary/route.js
@@ -1,0 +1,295 @@
+import crypto from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { unstable_cache } from "next/cache";
+import { NextResponse } from "next/server";
+
+import { formatDuration, monthsBetween } from "@/utils/experience/dateMath";
+import { parseExperienceFromPdf } from "@/utils/experience/pdfExperienceParser";
+
+// Node runtime required: `node:fs` for the PDF read, pdf-parse's CJS
+// build for parsing. Same pin convention as every other crypto/fs route
+// in this repo — explicit so a stray move to Edge can't silently break
+// bundling.
+export const runtime = "nodejs";
+
+// Cache the combined GitHub + PDF payload for 10 minutes. Originally
+// 24h because the inputs change monthly at most, but the modal now
+// renders a live list of owned repos (rename/create/delete) so the
+// TTL has to be short enough that those operations propagate to the
+// UI within minutes. 10 min matches /api/github-stats and keeps the
+// daily fetch volume per visitor in line with the other endpoint.
+// PDF parse is still cheap relative to the GraphQL fan-out, so the
+// shorter TTL doesn't meaningfully increase server cost.
+const EXPERIENCE_REVALIDATE_SECONDS = 10 * 60;
+const EXPERIENCE_CACHE_TAG = "experience-summary";
+
+// Hard cap on owned-repo pagination. GitHub returns 100 per page, so
+// 10 pages covers up to 1,000 owned non-fork repos — comfortably above
+// any realistic personal account. Above this we stop paging and the
+// list reflects approximately the most-recent 1,000 repos.
+const MAX_OWNED_REPO_PAGES = 10;
+
+// Edge / CDN cache window. Mirrors the github-stats route's headers so
+// the about page can request both endpoints on mount and have them
+// share TTL semantics. `stale-if-error` gives a full day of grace if
+// the upstream chain (GitHub + PDF parse) starts failing.
+const RESPONSE_CACHE_HEADERS = {
+  "Cache-Control":
+    "public, s-maxage=600, stale-while-revalidate=300, stale-if-error=86400",
+};
+
+const GITHUB_API = "https://api.github.com/graphql";
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GITHUB_TIMEOUT_MS =
+  Number(process.env.GITHUB_TIMEOUT_MS) || 8000;
+
+// Restrict by username for the same reason `/api/github-stats` does —
+// without an allowlist, any caller varying `?username=` would trigger a
+// fresh expensive computation against the shared token and pollute
+// `unstable_cache` with junk keys.
+const ALLOWED_USERNAME = (
+  process.env.NEXT_PUBLIC_GITHUB_USERNAME || "MA1002643"
+).toLowerCase();
+
+// Resolve `public/<file>` to a path the function can read at runtime.
+// On Vercel, `public/` is bundled into the deployment under the project
+// root, so `process.cwd()` is the right anchor — works in dev, on
+// Vercel, and in self-hosted Node alike.
+const RESUME_PDF_PATH = path.join(
+  process.cwd(),
+  "public",
+  "Muhammad_Abdullah_CV.pdf",
+);
+
+// Stable JSON serializer: sorts object keys recursively so two
+// structurally equal payloads always hash to the same digest. Arrays
+// preserve order because role order is meaningful (sorted by date).
+// Used only for the change-fingerprint — never for response shaping,
+// where insertion order matches the spec's documented payload.
+function stableStringify(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const keys = Object.keys(value).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`)
+    .join(",")}}`;
+}
+
+// Truncated SHA-256 of the content-relevant payload fields. 16 hex
+// chars (64 bits) is overkill collision-resistance for a UI diff
+// signal but keeps the wire payload compact. Excludes `generatedAt`
+// (time-based, would change every call) and `changeFingerprint` itself
+// (would otherwise depend on its own output).
+function buildFingerprint(payload) {
+  const { generatedAt, changeFingerprint, ...content } = payload;
+  const hex = crypto
+    .createHash("sha256")
+    .update(stableStringify(content))
+    .digest("hex");
+  return `sha256-${hex.slice(0, 16)}`;
+}
+
+// Single-call GraphQL wrapper used by the owned-repos pagination loop.
+// Each call gets its own AbortController + timeout so a stalled fetch
+// can't hold the serverless function past its budget. Extracted so the
+// loop body stays focused on pagination logic.
+async function githubGraphQL(query, variables) {
+  if (!GITHUB_TOKEN) {
+    throw new Error("GITHUB_TOKEN not set");
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GITHUB_TIMEOUT_MS);
+  try {
+    const res = await fetch(GITHUB_API, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`GitHub API ${res.status} ${res.statusText}`);
+    }
+    const json = await res.json();
+    if (json.errors) {
+      throw new Error(json.errors[0]?.message ?? "GraphQL error");
+    }
+    return json?.data;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Fetch every owned, non-fork repository the account has, paginated and
+// ordered newest-first. `ownerAffiliations: OWNER` excludes contributor
+// / member repos; `isFork: false` excludes forks (those weren't created
+// by this account). Returns `{ name, createdAt, url }` records in DESC
+// order so the modal can render newest-first; the earliest createdAt is
+// always the last element. Bounded by MAX_OWNED_REPO_PAGES so a malformed
+// pageInfo can't infinite-loop.
+async function fetchOwnedRepos(username) {
+  const query = `
+    query OwnedRepos($username: String!, $after: String) {
+      user(login: $username) {
+        repositories(
+          first: 100
+          after: $after
+          ownerAffiliations: OWNER
+          isFork: false
+          orderBy: { field: CREATED_AT, direction: DESC }
+        ) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            name
+            createdAt
+            url
+          }
+        }
+      }
+    }
+  `;
+  const repos = [];
+  let cursor = null;
+  for (let page = 0; page < MAX_OWNED_REPO_PAGES; page++) {
+    const data = await githubGraphQL(query, { username, after: cursor });
+    const conn = data?.user?.repositories;
+    if (!conn) break;
+    for (const node of conn.nodes ?? []) {
+      if (!node?.name || !node?.createdAt) continue;
+      repos.push({
+        name: node.name,
+        createdAt: node.createdAt,
+        url: node.url ?? null,
+      });
+    }
+    if (!conn.pageInfo?.hasNextPage) break;
+    cursor = conn.pageInfo.endCursor;
+  }
+  return repos;
+}
+
+// Per-side error tolerance: if GitHub fails we still return employment;
+// if the PDF fails we still return personal projects. Only when both
+// fail do we surface a 500 to the caller. Each side logs its own
+// failure so on-call doesn't have to correlate timestamps.
+async function buildExperienceSummary(username) {
+  const now = new Date();
+
+  // Run both fetches in parallel — they're independent and each has
+  // its own timeout, so the slower one bounds wall-clock.
+  const [githubResult, pdfResult] = await Promise.allSettled([
+    fetchOwnedRepos(username),
+    fs.readFile(RESUME_PDF_PATH).then((buf) => parseExperienceFromPdf(buf)),
+  ]);
+
+  let personalProjects = null;
+  if (githubResult.status === "fulfilled" && githubResult.value?.length > 0) {
+    // Repos are ordered DESC by createdAt (see fetchOwnedRepos), so the
+    // last element is the oldest — that's the anchor for the months
+    // calculation. The full list is exposed to the client so the modal
+    // can render every repo with its creation date; including it in
+    // the response also folds rename/create/delete events into the
+    // payload's `changeFingerprint` (so Phase 5's banner will announce
+    // a "new repo detected" change naturally without bespoke wiring).
+    const repos = githubResult.value;
+    const earliest = new Date(repos[repos.length - 1].createdAt);
+    const months = Math.max(0, monthsBetween(earliest, now));
+    personalProjects = {
+      firstRepoDate: earliest.toISOString().slice(0, 10),
+      months,
+      display: formatDuration(months),
+      repos,
+    };
+  } else if (githubResult.status === "rejected") {
+    console.warn(
+      "experience-summary: GitHub owned-repos lookup failed:",
+      githubResult.reason?.message ?? githubResult.reason,
+    );
+  }
+
+  let employment = null;
+  if (pdfResult.status === "fulfilled") {
+    const roles = pdfResult.value?.roles ?? [];
+    const months = roles.reduce((sum, r) => sum + r.months, 0);
+    employment = {
+      months,
+      display: formatDuration(months),
+      roles,
+    };
+  } else {
+    console.warn(
+      "experience-summary: resume PDF parse failed:",
+      pdfResult.reason?.message ?? pdfResult.reason,
+    );
+  }
+
+  if (!personalProjects && !employment) {
+    // Both sides failed — let the caller serve an error rather than
+    // synthesise a misleading "0 months" total.
+    throw new Error("Both GitHub and PDF sources failed");
+  }
+
+  const totalMonths =
+    (personalProjects?.months ?? 0) + (employment?.months ?? 0);
+
+  const payload = {
+    generatedAt: now.toISOString(),
+    personalProjects,
+    employment,
+    total: {
+      months: totalMonths,
+      display: formatDuration(totalMonths),
+    },
+  };
+  payload.changeFingerprint = buildFingerprint(payload);
+  return payload;
+}
+
+// `unstable_cache` keys by the function args. We pass the canonical
+// (lowercase) username so the cache key is stable regardless of how the
+// allowlist check arrived at it. Same defensive pattern as
+// `getCachedGithubStats`.
+const getCachedExperienceSummary = unstable_cache(
+  async (username) => buildExperienceSummary(username),
+  ["experience-summary"],
+  {
+    revalidate: EXPERIENCE_REVALIDATE_SECONDS,
+    tags: [EXPERIENCE_CACHE_TAG],
+  },
+);
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const username = searchParams.get("username");
+
+  if (!username) {
+    return NextResponse.json(
+      { error: "Missing 'username' query parameter." },
+      { status: 400 },
+    );
+  }
+  if (username.toLowerCase() !== ALLOWED_USERNAME) {
+    return NextResponse.json(
+      { error: "Username not allowed" },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const data = await getCachedExperienceSummary(ALLOWED_USERNAME);
+    return NextResponse.json(data, { headers: RESPONSE_CACHE_HEADERS });
+  } catch (error) {
+    console.error("experience-summary fetch failed:", error);
+    return NextResponse.json(
+      { error: "Failed to build experience summary" },
+      { status: 500, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/app/api/repo-refresh/route.js
+++ b/src/app/api/repo-refresh/route.js
@@ -21,12 +21,15 @@ export const dynamic = "force-dynamic";
 // Called by `/api/daily-warmup` (the scheduled cron entrypoint in
 // vercel.json, which orchestrates this route + the work-status bust) or
 // invoked manually with the bearer token to force a refresh outside the
-// daily schedule. Job: invalidate the `github-stats` + `most-active-repo`
-// cache tags and warm the cache by hitting /api/github-stats once, so the
-// first real user request after midnight is instant. Authenticated via
-// CRON_SECRET in the Authorization header — Vercel Cron forwards it on
-// the scheduled call, and `/api/daily-warmup` forwards the same header on
-// the orchestrated call.
+// daily schedule. Job: invalidate the `github-stats`,
+// `most-active-repo`, and `experience-summary` cache tags and warm
+// /api/github-stats + /api/experience-summary so the first morning
+// visitor lands on hot data. Authenticated via CRON_SECRET in the
+// Authorization header — Vercel Cron forwards it on the scheduled
+// call, and `/api/daily-warmup` forwards the same header on the
+// orchestrated call. The experience-summary cache is on a 10-min TTL
+// already, but the daily revalidation ensures the cache rolls even
+// during low-traffic days where no client poll happens.
 export async function GET(request) {
   // Read the secret once and guard explicitly. Without this, an unset
   // CRON_SECRET would let `Bearer undefined` pass as a valid credential —
@@ -70,6 +73,11 @@ export async function GET(request) {
     // and the freshly-scored most-active repo lands in the warm cache.
     revalidateTag("github-stats");
     revalidateTag("most-active-repo");
+    // experience-summary is also tag-cached; included here so the daily
+    // cron rolls all three caches in lockstep. The endpoint already has
+    // a 10-min TTL for normal client-driven refresh, but the daily
+    // revalidation guarantees turnover even on low-traffic days.
+    revalidateTag("experience-summary");
 
     // Bypass two distinct cache layers when warming:
     //   1. `cache: "no-store"` + `Cache-Control: no-cache` request header
@@ -136,10 +144,40 @@ export async function GET(request) {
       );
     }
 
+    // Best-effort warm of /api/experience-summary. Isolated try/catch
+    // so a failure here doesn't downgrade the github-stats success
+    // signal — the experience-summary cache was already invalidated
+    // above and will rebuild on the next client poll if this warm
+    // fails. Reuses the same `cacheBust` so a single timestamp tags
+    // both warm fetches in logs.
+    let experience = { ok: false, attempted: false };
+    try {
+      const expRes = await fetch(
+        `${baseUrl}/api/experience-summary?username=${encodeURIComponent(username)}&_=${cacheBust}`,
+        {
+          cache: "no-store",
+          headers: { "Cache-Control": "no-cache" },
+        }
+      );
+      experience = { ok: expRes.ok, attempted: true, status: expRes.status };
+      if (!expRes.ok) {
+        console.warn(
+          `repo-refresh: /api/experience-summary returned ${expRes.status} ${expRes.statusText}`
+        );
+      }
+    } catch (err) {
+      console.warn(
+        "repo-refresh: experience-summary warm failed:",
+        err?.message ?? err
+      );
+      experience = { ok: false, attempted: true, error: err?.message ?? String(err) };
+    }
+
     return noStoreJson({
       ok: true,
       repo: data?.stats?.repo?.name ?? null,
       activityScore: data?.stats?.repo?.activityScore ?? null,
+      experience,
     });
   } catch (err) {
     console.error("repo-refresh cron error:", err);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,11 +27,15 @@
   .custom-bg-abt {
     @apply border border-solid;
     border-color: #ffcd5bcc;
-    /* golden border */
-    background-color: #00000020;
-    /* subtle transparent dark bg */
-    backdrop-filter: blur(6px);
-    /* neon blur */
+    /* Slate-and-gold interior — was a flat `#00000020`; lifted up
+       from the former `.elite-card` modifier so every card on the
+       about page shares the same rich background instead of the
+       years card being the lone richly-toned outlier. The warm gold
+       neon border + glow below sit on top of this surface. */
+    background:
+      radial-gradient(circle at 30% 0%, rgba(244, 227, 184, 0.06), transparent 55%),
+      linear-gradient(135deg, rgba(8, 11, 22, 0.92), rgba(2, 6, 23, 0.88));
+    backdrop-filter: blur(12px);
     box-shadow:
       0 0 0px #ff8400,
       0 0 0px #ffaa2a,
@@ -45,6 +49,38 @@
       0 0 1px #ff8400,
       0 0 2px #ffaa2a,
       0 0 8px orangered;
+  }
+
+  .text-gold {
+    color: #f4e3b8;
+    text-shadow: 0 0 14px rgba(212, 175, 122, 0.35);
+  }
+
+  .text-gold-muted {
+    color: #d4af7a;
+  }
+
+  .text-gold-soft {
+    color: #b8946a;
+  }
+
+  .text-cyan-cool {
+    color: #bae6fd;
+  }
+
+  /* Static divider — solid vivid orange matching the "3+" /
+     "1+" CategoryCount digits, fading to transparent at the
+     edges so it reads as a line rather than a bar. Subtle warm
+     halo via box-shadow. */
+  .elite-divider {
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      #ff6d05 12%,
+      #ff6d05 88%,
+      transparent 100%
+    );
+    box-shadow: 0 0 8px rgba(255, 109, 5, 0.3);
   }
 
   .custom-bg {
@@ -96,6 +132,30 @@
       0 0 4px #d1970e,
       0 0 10px #b16612;
     color: #d3b883;
+  }
+
+  /* Elite fire-gradient text — vertical bright-amber → vivid-orange
+     fill clipped to the text shape, with two layers of warm drop-
+     shadow giving a heat-haze halo. Each letter looks like it's
+     glowing from within against the slate card background. Pairs
+     with the per-word opacity reveal in <RevealWord /> — as a word
+     fades in, the gradient renders at its position so the paragraph
+     reads like fire "burning into existence" on scroll. */
+  .text-fire-amber {
+    background: linear-gradient(
+      180deg,
+      #ffd27d 0%,
+      #ffbb55 40%,
+      #ffaa2a 70%,
+      #ff6d05 100%
+    );
+    -webkit-background-clip: text;
+            background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    filter:
+      drop-shadow(0 0 4px rgba(255, 178, 60, 0.55))
+      drop-shadow(0 0 12px rgba(255, 73, 0, 0.35));
   }
 
   .behind-glow {
@@ -466,6 +526,14 @@ html {
   top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
   left: calc(env(safe-area-inset-left, 0px) + 0.75rem);
   z-index: 120;
+}
+
+/* Hide the home button while a modal owns the screen. The
+   experience-breakdown modal sets `data-modal-open` on <body> when
+   it opens; without this rule the home button (z:120) would float
+   above the modal's z:50 backdrop on every viewport. */
+body[data-modal-open] .control-island {
+  display: none;
 }
 
 /* Suppress hover-only tooltip UI on touch devices */

--- a/src/components/about/ExperienceBreakdownModal.jsx
+++ b/src/components/about/ExperienceBreakdownModal.jsx
@@ -50,7 +50,11 @@ function AnimatedNumber({ value }) {
 // the final value with no animation.
 function CategoryCount({ months }) {
   const value = months >= 12 ? Math.floor(months / 12) : months;
-  const unit = months >= 12 ? "years" : "months";
+  // Singular when the count is exactly 1, matching RoleBar's plural-
+  // aware rendering. Without this the 12–23-month window reads "1+
+  // years" — the same window RoleBar correctly prints as "1+ year".
+  const baseUnit = months >= 12 ? "year" : "month";
+  const unit = value === 1 ? baseUnit : `${baseUnit}s`;
   const nodeRef = useRef(null);
   const sectionRef = useRef(null);
   const prefersReducedMotion = useReducedMotion();

--- a/src/components/about/ExperienceBreakdownModal.jsx
+++ b/src/components/about/ExperienceBreakdownModal.jsx
@@ -1,0 +1,741 @@
+"use client";
+
+import { animate, AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { X } from "lucide-react";
+import { Fragment, useEffect, useRef, useState } from "react";
+
+import { useViewportCountTrigger } from "@/hooks/useViewportCountTrigger";
+
+// Generic numeric count-up. Renders an integer that ticks 0 → value
+// on viewport entry, then holds. Same animate()/viewport-trigger
+// pattern as the years card's Counter so every number on the modal
+// uses the same easing curve and duration. Suffix / unit text is
+// rendered by the caller as a sibling so this component stays
+// reusable for "4+", "10 repositories", "3+ months", etc.
+function AnimatedNumber({ value }) {
+  const nodeRef = useRef(null);
+  const sectionRef = useRef(null);
+  const prefersReducedMotion = useReducedMotion();
+  const { playToken } = useViewportCountTrigger(sectionRef, { amount: 0.3 });
+
+  useEffect(() => {
+    const node = nodeRef.current;
+    if (!node) return;
+    if (prefersReducedMotion) {
+      node.textContent = String(value);
+      return;
+    }
+    if (playToken === 0) return;
+    const controls = animate(0, value, {
+      duration: 1.2,
+      onUpdate: (v) => {
+        node.textContent = v.toFixed(0);
+      },
+    });
+    return () => controls.stop();
+  }, [value, playToken, prefersReducedMotion]);
+
+  return (
+    <span ref={sectionRef} className="inline-block tabular-nums">
+      <span ref={nodeRef}>{prefersReducedMotion ? value : 0}</span>
+    </span>
+  );
+}
+
+// Lightweight count-up for the modal's category totals. Mirrors the
+// trigger-once-per-entry-cycle pattern used by the about page's main
+// Counter — `useViewportCountTrigger` plus a re-mount per modal open
+// (the modal is conditionally rendered) means each open replays the
+// animation cleanly without a manual reset. Reduced motion lands on
+// the final value with no animation.
+function CategoryCount({ months }) {
+  const value = months >= 12 ? Math.floor(months / 12) : months;
+  const unit = months >= 12 ? "years" : "months";
+  const nodeRef = useRef(null);
+  const sectionRef = useRef(null);
+  const prefersReducedMotion = useReducedMotion();
+  const { playToken } = useViewportCountTrigger(sectionRef, { amount: 0.3 });
+
+  useEffect(() => {
+    const node = nodeRef.current;
+    if (!node) return;
+    if (prefersReducedMotion) {
+      node.textContent = String(value);
+      return;
+    }
+    if (playToken === 0) return;
+    const controls = animate(0, value, {
+      duration: 1.2,
+      onUpdate: (v) => {
+        node.textContent = v.toFixed(0);
+      },
+    });
+    return () => controls.stop();
+  }, [value, playToken, prefersReducedMotion]);
+
+  return (
+    <span ref={sectionRef} className="inline-flex items-baseline gap-1 tabular-nums">
+      <span className="sr-only">{`${value}+ ${unit}`}</span>
+      <span
+        aria-hidden="true"
+        className="text-2xl sm:text-3xl font-semibold"
+        style={{ color: "#ff6d05", textShadow: "none" }}
+      >
+        <span ref={nodeRef}>{prefersReducedMotion ? value : 0}</span>
+        <span>+</span>
+      </span>
+      <span aria-hidden="true" className="text-sm sm:text-base text-fire-amber">
+        {unit}
+      </span>
+    </span>
+  );
+}
+
+// Donut chart visualising the personal-vs-employment split of total
+// experience. Two arcs share a single track; the second arc is rotated
+// by the first arc's sweep so they meet at the seam. Center reads the
+// grand total — same value the years card on the about page shows, so
+// opening the modal feels like a zoom-in rather than a new metric.
+function ExperienceDonut({ personalMonths, employmentMonths }) {
+  const prefersReducedMotion = useReducedMotion();
+  const total = personalMonths + employmentMonths;
+  if (total === 0) return null;
+
+  const personalPct = personalMonths / total;
+  const employmentPct = employmentMonths / total;
+  const radius = 70;
+  const strokeWidth = 14;
+  const circumference = 2 * Math.PI * radius;
+  // Tiny rotational gap (in degrees) between the two arcs so the
+  // rounded caps don't visually overlap at the seam.
+  const gapDeg = 4;
+  const personalSweep = Math.max(0, personalPct * 360 - gapDeg);
+  const employmentSweep = Math.max(0, employmentPct * 360 - gapDeg);
+  const personalDash = (personalSweep / 360) * circumference;
+  const employmentDash = (employmentSweep / 360) * circumference;
+
+  const totalValue = total >= 12 ? Math.floor(total / 12) : total;
+  const totalUnit = total >= 12 ? "yrs" : "mo";
+
+  const arcInitial = prefersReducedMotion
+    ? { strokeDasharray: undefined }
+    : { strokeDashoffset: circumference };
+  const arcAnimateBase = prefersReducedMotion
+    ? {}
+    : { strokeDashoffset: 0 };
+
+  return (
+    <div className="relative mx-auto w-36 h-36 sm:w-44 sm:h-44">
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 180 180"
+        className="-rotate-90 block"
+        aria-hidden="true"
+      >
+        <defs>
+          {/* Personal arc — solid vivid orange, matching the "3+
+              years" CategoryCount color so the arc and its numeric
+              total read as the same metric. */}
+          <linearGradient id="elite-gold-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#ff6d05" />
+            <stop offset="100%" stopColor="#ff6d05" />
+          </linearGradient>
+          {/* Employment arc — solid bright amber so it reads as a
+              clearly lighter tone next to the Personal arc's vivid
+              orange. Was a bright-amber → vivid-orange gradient
+              but the orange endpoint blended into the Personal arc
+              at the seam. */}
+          <linearGradient id="elite-cyan-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#ffd27d" />
+            <stop offset="100%" stopColor="#ffd27d" />
+          </linearGradient>
+        </defs>
+
+        {/* Track */}
+        <circle
+          cx="90"
+          cy="90"
+          r={radius}
+          fill="none"
+          stroke="rgba(244, 227, 184, 0.06)"
+          strokeWidth={strokeWidth}
+        />
+
+        {/* Personal arc — starts at 12 o'clock (after SVG -rotate-90) */}
+        <motion.circle
+          cx="90"
+          cy="90"
+          r={radius}
+          fill="none"
+          stroke="url(#elite-gold-grad)"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={`${personalDash} ${circumference}`}
+          initial={arcInitial}
+          animate={arcAnimateBase}
+          transition={{ duration: 1.2, ease: "easeOut", delay: 0.15 }}
+        />
+
+        {/* Employment arc — rotated to start where personal ended (+gap) */}
+        <motion.circle
+          cx="90"
+          cy="90"
+          r={radius}
+          fill="none"
+          stroke="url(#elite-cyan-grad)"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={`${employmentDash} ${circumference}`}
+          style={{
+            transformOrigin: "90px 90px",
+            transform: `rotate(${personalPct * 360}deg)`,
+          }}
+          initial={arcInitial}
+          animate={arcAnimateBase}
+          transition={{ duration: 1.2, ease: "easeOut", delay: 0.45 }}
+        />
+      </svg>
+
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <span
+          className="text-3xl sm:text-4xl font-semibold tabular-nums"
+          style={{ color: "#ff6d05", textShadow: "none" }}
+        >
+          <AnimatedNumber value={totalValue} />+
+        </span>
+        <span className="text-[10px] uppercase tracking-[0.18em] text-fire-amber mt-1">
+          total {totalUnit}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Per-role horizontal bar — width is the role's share of the longest
+// role in the list, not of the total, so a 1-month stint still gets a
+// visible sliver and the longest role anchors at 100%. Bar animates
+// every time it enters view inside the modal's scroll container (not
+// just on first mount): `whileInView` with `once: false` and the
+// dialog element as `root` so scrolling the bar in and out of the
+// modal's visible region replays the fill animation. `containerRef`
+// is the dialog scroller, threaded through from the parent so this
+// detail stays local to the modal.
+function RoleBar({ role, maxMonths, index, containerRef }) {
+  const prefersReducedMotion = useReducedMotion();
+  const pct = maxMonths > 0 ? Math.max(4, (role.months / maxMonths) * 100) : 0;
+  // Split the pre-formatted `role.display` into its leading numeric
+  // segment and the trailing unit + sentence so the number can animate
+  // independently. Same rules as the server-side `formatDuration` (>=12
+  // months → "X+ years", else "X+ months"; singular/plural handled).
+  const isYears = role.months >= 12;
+  const leading = isYears ? Math.floor(role.months / 12) : role.months;
+  const unitWord = isYears
+    ? leading === 1
+      ? "year"
+      : "years"
+    : leading === 1
+      ? "month"
+      : "months";
+
+  return (
+    <li
+      className="grid gap-1 py-2"
+      style={{ gridTemplateColumns: "minmax(0, 1fr) auto" }}
+    >
+      <span
+        className="text-sm leading-snug min-w-0 truncate"
+        style={{ color: "#ff6d05", textShadow: "none" }}
+      >
+        <AnimatedNumber value={leading} />+{" "}
+        <span className="text-fire-amber">
+          {unitWord} with {role.company} as a {role.role}
+        </span>
+      </span>
+      <span className="text-xs text-[#ffaa2a] tabular-nums self-center">
+        <AnimatedNumber value={leading} />
+        {isYears ? "+ yrs" : " mo"}
+      </span>
+      <div
+        className="col-span-2 h-1.5 rounded-full overflow-hidden"
+        style={{ background: "rgba(244, 227, 184, 0.05)" }}
+      >
+        <motion.div
+          className="h-full rounded-full"
+          style={{
+            background:
+              "linear-gradient(90deg, #ffd27d 0%, #ffaa2a 60%, #ff6d05 100%)",
+            boxShadow: "0 0 8px rgba(255, 109, 5, 0.45)",
+          }}
+          initial={prefersReducedMotion ? { width: `${pct}%` } : { width: 0 }}
+          whileInView={{ width: `${pct}%` }}
+          viewport={{ once: false, amount: 0.5, root: containerRef }}
+          transition={{
+            duration: 0.9,
+            delay: 0.3 + index * 0.12,
+            ease: "easeOut",
+          }}
+        />
+      </div>
+    </li>
+  );
+}
+
+// Repo name row in the Personal Projects list. The repo name uses
+// `truncate` (text-overflow: ellipsis) so long names don't wrap. A
+// `title` attribute is set only when the text is actually clipped —
+// otherwise the browser would render its native unstyled tooltip on
+// every hover even when the full name was already visible. A
+// ResizeObserver re-checks on container width changes so the tooltip
+// turns on/off as the modal is resized.
+function RepoName({ repo }) {
+  const ref = useRef(null);
+  const [isClipped, setIsClipped] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const check = () => setIsClipped(el.scrollWidth > el.clientWidth);
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [repo.name]);
+
+  const titleAttr = isClipped ? repo.name : undefined;
+
+  if (repo.url) {
+    return (
+      <a
+        ref={ref}
+        href={repo.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={titleAttr}
+        className="block truncate text-fire-amber underline-offset-2 hover:underline transition-colors"
+      >
+        {repo.name}
+      </a>
+    );
+  }
+  return (
+    <span
+      ref={ref}
+      title={titleAttr}
+      className="block truncate text-fire-amber"
+    >
+      {repo.name}
+    </span>
+  );
+}
+
+// Focusable element selector for the focus trap. Matches everything an
+// AT user can reach via Tab. Element-level `[tabindex="-1"]` is
+// excluded so programmatic-only focus targets don't intercept the
+// trap cycle.
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+// Initial number of repos shown before the disclosure expands. Tuned
+// so the modal opens at a compact height even on accounts with many
+// owned repos; users with curiosity can expand to the full list.
+const REPO_INITIAL_LIMIT = 5;
+
+/**
+ * Experience breakdown modal — opens from the years card on the about
+ * page. Shows GitHub-derived personal-projects total and resume-derived
+ * employment total + per-role lines, with a donut chart visualising the
+ * split.
+ *
+ * Full a11y baseline (per the Phase 4 choice):
+ *   - `role="dialog"` + `aria-modal="true"` + `aria-labelledby` so
+ *     screen readers announce it as a modal dialog with the title.
+ *   - Escape key closes.
+ *   - Backdrop click closes; inner-panel clicks don't propagate.
+ *   - Focus moves to the close button on open.
+ *   - Tab / Shift+Tab cycles within the dialog (focus trap).
+ *   - Focus returns to the trigger element on close.
+ *   - `document.body.style.overflow` locked while open so background
+ *     scroll doesn't compete with modal scroll on touch.
+ *
+ * @param {object} props
+ * @param {boolean} props.open
+ * @param {() => void} props.onClose
+ * @param {object|null} props.data         - experience-summary payload
+ * @param {React.RefObject<HTMLElement>} props.triggerRef - element that opened the modal
+ */
+export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
+  const dialogRef = useRef(null);
+  // Inner scrolling region is the actual `overflow-y-auto` element so
+  // the browser's scrollbar lands inside the gold border instead of
+  // sitting on top of it. The outer dialog stays `overflow-hidden`
+  // so its rounded corners clip the scrollbar; this inner div is the
+  // one that scrolls and the one we hand to RoleBar's `whileInView`
+  // as a custom `root`, so progress bars re-fire on internal scroll.
+  const scrollRef = useRef(null);
+  const closeButtonRef = useRef(null);
+  const [showAllRepos, setShowAllRepos] = useState(false);
+
+  // Reset disclosure state on every re-open so the modal always starts
+  // in its compact form. Otherwise reopening after expanding once would
+  // skip past the visual "compact → expanded" hint that exists to
+  // signal more rows are available.
+  useEffect(() => {
+    if (open) setShowAllRepos(false);
+  }, [open]);
+
+  // Body scroll lock — restore prior value on close so we don't clobber
+  // a different overflow setting that might be set elsewhere. Also
+  // sets `data-modal-open` on <body> so the floating home button
+  // (`.control-island`, z:120) can be hidden via CSS while the modal
+  // is open — otherwise it sits above the z-50 backdrop and remains
+  // tappable, breaking the modal's focus feel and letting users
+  // navigate away from underneath the dialog.
+  useEffect(() => {
+    if (!open) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.body.dataset.modalOpen = "true";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      delete document.body.dataset.modalOpen;
+    };
+  }, [open]);
+
+  // Escape closes. Keydown bound at document level so the listener
+  // fires regardless of which dialog descendant has focus.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  // Focus management. On open: move focus to the close button so the
+  // first Tab cycle starts inside the dialog. On close: return focus
+  // to the originating trigger element (the years card) if still in
+  // the DOM — matches the WAI-ARIA dialog practices guide.
+  useEffect(() => {
+    if (!open) return;
+    closeButtonRef.current?.focus();
+    const trigger = triggerRef?.current;
+    return () => {
+      if (trigger && document.body.contains(trigger)) {
+        trigger.focus();
+      }
+    };
+  }, [open, triggerRef]);
+
+  // Focus trap. We intercept Tab/Shift+Tab at the dialog and wrap
+  // focus around the first/last focusable elements so Tab never
+  // escapes back to the page beneath. Re-queried on each Tab to
+  // tolerate dynamic content (e.g. roles list rendering after data
+  // arrives).
+  useEffect(() => {
+    if (!open) return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const handler = (e) => {
+      if (e.key !== "Tab") return;
+      const focusables = dialog.querySelectorAll(FOCUSABLE_SELECTOR);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    dialog.addEventListener("keydown", handler);
+    return () => dialog.removeEventListener("keydown", handler);
+  }, [open]);
+
+  const personalMonths = data?.personalProjects?.months ?? 0;
+  const employmentMonths = data?.employment?.months ?? 0;
+  const roles = data?.employment?.roles ?? [];
+  const repos = data?.personalProjects?.repos ?? [];
+  const maxRoleMonths = roles.reduce((m, r) => Math.max(m, r.months), 0);
+  const visibleRepos = showAllRepos ? repos : repos.slice(0, REPO_INITIAL_LIMIT);
+  const hasMoreRepos = repos.length > REPO_INITIAL_LIMIT;
+
+  // Repos arrive in DESC-by-createdAt order (newest first) from the
+  // API. Date formatter renders "Mar 4, 2023"-style readable dates
+  // anchored in UTC so a non-UTC client locale can't shift the day.
+  const formatRepoDate = (iso) => {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    });
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.25 }}
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-md"
+          onClick={onClose}
+        >
+          <motion.div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="experience-modal-title"
+            initial={{ opacity: 0, scale: 0.96, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 12 }}
+            transition={{ type: "spring", stiffness: 280, damping: 28 }}
+            // Reuses the about page's shared card chrome
+            // (`.custom-bg-abt`) so the modal panel inherits the exact
+            // same warm-gold border, slate gradient interior, backdrop
+            // blur, orange neon box-shadow AND the brighter on-hover
+            // box-shadow that every card on the about page already
+            // uses. `overflow-hidden` on this outer panel so the
+            // rounded corners clip the scrollbar that lives on the
+            // inner `scrollRef` div — keeps the scrollbar inside the
+            // gold border rather than sitting on top of it.
+            className="custom-bg-abt rounded-2xl w-full max-w-2xl max-h-[88vh] overflow-hidden text-white relative"
+            style={{
+              filter: "drop-shadow(0 24px 60px rgba(0, 0, 0, 0.6))",
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div
+              ref={scrollRef}
+              className="max-h-[88vh] overflow-y-auto p-6 sm:p-8"
+            >
+            <header className="flex items-start justify-between gap-4 mb-6">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.22em] text-[#ffaa2a] mb-1">
+                  Career snapshot
+                </p>
+                <h2
+                  id="experience-modal-title"
+                  className="text-xl sm:text-2xl font-semibold"
+                  style={{ color: "#ff6d05", textShadow: "none" }}
+                >
+                  Experience by category
+                </h2>
+              </div>
+              <button
+                ref={closeButtonRef}
+                type="button"
+                onClick={onClose}
+                aria-label="Close experience breakdown"
+                // Reuses the home button's `.custom-bg` class so the
+                // close button inherits the exact same orange neon
+                // border + subtle outer glow at rest AND the brighter
+                // multi-layered glow on hover. Icon uses an SVG (X
+                // from lucide-react) for reliable centering — the "×"
+                // text glyph has asymmetric vertical metrics that
+                // nudge it off-center in most fonts.
+                className="custom-bg flex-shrink-0 w-9 h-9 inline-flex items-center justify-center rounded-full text-[#d4af7a] hover:text-[#ff6d05] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/50"
+              >
+                <X aria-hidden="true" className="w-4 h-4" strokeWidth={2} />
+              </button>
+            </header>
+
+            {/* Hero block — donut + legend. Stacks on mobile so the
+                donut stays large enough to read. */}
+            <div className="flex flex-col sm:flex-row items-center gap-6 mb-8">
+              <ExperienceDonut
+                personalMonths={personalMonths}
+                employmentMonths={employmentMonths}
+              />
+              <dl className="flex-1 w-full space-y-4">
+                <div>
+                  <dt className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[#ffaa2a] mb-1">
+                    <span
+                      aria-hidden="true"
+                      className="inline-block w-2.5 h-2.5 rounded-full"
+                      style={{
+                        background: "#ff6d05",
+                        boxShadow: "0 0 8px rgba(255, 109, 5, 0.6)",
+                      }}
+                    />
+                    Personal Projects
+                  </dt>
+                  <dd>
+                    <CategoryCount months={personalMonths} />
+                    {repos.length > 0 && (
+                      <span className="block text-xs text-[#ffbb55] mt-0.5">
+                        <AnimatedNumber value={repos.length} /> owned {repos.length === 1 ? "repository" : "repositories"}
+                      </span>
+                    )}
+                  </dd>
+                </div>
+                <div
+                  aria-hidden="true"
+                  className="h-px elite-divider"
+                />
+                <div>
+                  <dt className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[#ffaa2a] mb-1">
+                    <span
+                      aria-hidden="true"
+                      className="inline-block w-2.5 h-2.5 rounded-full"
+                      style={{
+                        background: "#ffd27d",
+                        boxShadow: "0 0 8px rgba(255, 210, 125, 0.6)",
+                      }}
+                    />
+                    Employment
+                  </dt>
+                  <dd>
+                    <CategoryCount months={employmentMonths} />
+                    {roles.length > 0 && (
+                      <span className="block text-xs text-[#ffbb55] mt-0.5">
+                        <AnimatedNumber value={roles.length} /> {roles.length === 1 ? "role" : "roles"}
+                      </span>
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+
+            <section className="mb-7">
+              <header className="flex items-center justify-between mb-3">
+                <h3 className="text-[11px] uppercase tracking-[0.2em] text-[#ffaa2a]">
+                  Personal Projects
+                </h3>
+                {repos.length > 0 && (
+                  <span className="text-[10px] uppercase tracking-[0.16em] text-[#d4af7a]">
+                    Newest first
+                  </span>
+                )}
+              </header>
+              {repos.length > 0 ? (
+                <>
+                  <ul
+                    role="list"
+                    className="custom-bg-abt rounded-lg p-2 space-y-1.5"
+                  >
+                    {visibleRepos.map((r) => {
+                      const dateText = formatRepoDate(r.createdAt);
+                      return (
+                        <li
+                          key={r.url ?? r.name}
+                          className="flex items-center gap-3 text-sm leading-snug"
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="flex-shrink-0 w-1.5 h-1.5 rounded-full"
+                            style={{
+                              background: "#ff6d05",
+                              boxShadow: "0 0 6px rgba(255, 109, 5, 0.55)",
+                            }}
+                          />
+                          <div className="flex-1 min-w-0">
+                            <RepoName repo={r} />
+                          </div>
+                          <time
+                            dateTime={r.createdAt}
+                            className="flex-shrink-0 text-xs text-[#ffaa2a] tabular-nums"
+                          >
+                            {dateText}
+                          </time>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                  {hasMoreRepos && (
+                    <button
+                      type="button"
+                      onClick={() => setShowAllRepos((v) => !v)}
+                      className="mt-2 text-xs text-[#ffd27d] hover:text-[#ff6d05] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/40 rounded px-2 py-1 transition-colors"
+                      aria-expanded={showAllRepos}
+                    >
+                      {showAllRepos
+                        ? "Show fewer"
+                        : `Show all ${repos.length} repositories →`}
+                    </button>
+                  )}
+                </>
+              ) : (
+                <p className="text-xs text-fire-amber">
+                  No owned repositories detected yet.
+                </p>
+              )}
+            </section>
+
+            <section>
+              <header className="flex items-center justify-between mb-3">
+                <h3 className="text-[11px] uppercase tracking-[0.2em] text-[#ffaa2a]">
+                  Employment
+                </h3>
+                {roles.length > 0 && (
+                  <span className="text-[10px] uppercase tracking-[0.16em] text-[#d4af7a]">
+                    Relative duration
+                  </span>
+                )}
+              </header>
+              {roles.length > 0 ? (
+                <ul
+                  role="list"
+                  className="custom-bg-abt rounded-lg px-3 py-1"
+                >
+                  {roles.map((r, i) => (
+                    <Fragment key={`${r.company}-${r.role}-${r.start}`}>
+                      {i > 0 && (
+                        // Separator <li> between role rows. Using a
+                        // li (with role="presentation") keeps the
+                        // parent <ul role="list"> semantically pure
+                        // while letting block-flow margins control
+                        // the spacing — the previous grid-cell-based
+                        // approach left a residual track height that
+                        // couldn't be cancelled with negative margin.
+                        // -mb-1 pulls the next role up 4px to offset
+                        // the leading-snug line-box padding above
+                        // the role text, so the visible gap above
+                        // and below the line reads as equal.
+                        <li
+                          role="presentation"
+                          aria-hidden="true"
+                          className="h-px elite-divider -mx-3 list-none -mb-1"
+                        />
+                      )}
+                      <RoleBar
+                        role={r}
+                        maxMonths={maxRoleMonths}
+                        index={i}
+                        containerRef={scrollRef}
+                      />
+                    </Fragment>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-[#d4af7a]">
+                  No software-engineering roles detected yet.
+                </p>
+              )}
+            </section>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/about/ExperienceUpdateBanner.jsx
+++ b/src/components/about/ExperienceUpdateBanner.jsx
@@ -10,12 +10,25 @@ import { UpdateBanner } from "./UpdateBanner";
 // attention.
 const VISIBLE_DURATION_MS = 4500;
 
+// sessionStorage key for the last message played in this tab. Cleared
+// automatically when the tab closes; survives soft remounts (route
+// changes, re-renders) so the banner doesn't re-fire after the user
+// navigates away from /about and back within the same session.
+const SESSION_KEY = "experience-update-banner:lastPlayed";
+
 /**
  * Inline banner that appears inside the years card the first time the
  * user scrolls into view *after* the experience summary changes. Each
  * distinct message is shown at most once per browser session — re-
  * entries with the same message are silently skipped (no nag), but a
  * fresh message from a later poll re-arms the trigger.
+ *
+ * Session-scope dedupe is persisted to `sessionStorage`, so it survives
+ * component remounts (route changes, soft reloads) but clears when the
+ * tab closes — that's the "browser session" boundary the docstring
+ * promises. In environments where `sessionStorage` is unavailable
+ * (private browsing on some platforms, locked-down embeds), we silently
+ * fall back to in-memory dedupe scoped to the component lifetime.
  *
  * Visual is delegated to the shared `UpdateBanner` so the experience
  * banner uses the exact same look-and-feel as every other update
@@ -41,15 +54,36 @@ const VISIBLE_DURATION_MS = 4500;
  */
 export function ExperienceUpdateBanner({ message, inView, variant = "orange" }) {
   const [shown, setShown] = useState(false);
-  // Remembers which message we've already played so re-entries with
-  // the same message don't re-show it. A new message coming in (the
-  // ref doesn't match) re-arms the trigger.
+  // Remembers which message we've already played so re-entries with the
+  // same message don't re-show it. Hydrated from sessionStorage on first
+  // run via `hydratedRef`, then kept in sync with each new banner fire.
   const lastPlayedRef = useRef(null);
+  const hydratedRef = useRef(false);
 
   useEffect(() => {
+    // First-run hydration. Done inside the main effect (rather than a
+    // separate mount effect) so the read completes before any banner
+    // decision is made on this same render — no narrow race where the
+    // banner fires once before sessionStorage is consulted.
+    if (!hydratedRef.current) {
+      hydratedRef.current = true;
+      try {
+        lastPlayedRef.current = window.sessionStorage.getItem(SESSION_KEY);
+      } catch {
+        // sessionStorage unavailable — in-memory dedupe still works for
+        // this component lifetime, which matches the prior behavior.
+      }
+    }
     if (!message || !inView) return;
     if (lastPlayedRef.current === message) return;
     lastPlayedRef.current = message;
+    try {
+      window.sessionStorage.setItem(SESSION_KEY, message);
+    } catch {
+      // Write failure is non-fatal: the in-memory ref still prevents
+      // re-fires for the rest of this component's lifetime, and the
+      // next mount falls back to lifetime-scoped dedupe.
+    }
     setShown(true);
     const timer = setTimeout(() => setShown(false), VISIBLE_DURATION_MS);
     return () => clearTimeout(timer);

--- a/src/components/about/ExperienceUpdateBanner.jsx
+++ b/src/components/about/ExperienceUpdateBanner.jsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { UpdateBanner } from "./UpdateBanner";
+
+// Auto-dismiss timeout — 4.5s sits comfortably in the spec's "4-5
+// seconds" window. Long enough for the user to read a one-line
+// sentence, short enough that it doesn't linger past the moment of
+// attention.
+const VISIBLE_DURATION_MS = 4500;
+
+/**
+ * Inline banner that appears inside the years card the first time the
+ * user scrolls into view *after* the experience summary changes. Each
+ * distinct message is shown at most once per browser session — re-
+ * entries with the same message are silently skipped (no nag), but a
+ * fresh message from a later poll re-arms the trigger.
+ *
+ * Visual is delegated to the shared `UpdateBanner` so the experience
+ * banner uses the exact same look-and-feel as every other update
+ * banner on the about page (RepoStatsCard, StatsCard, etc.) instead
+ * of carrying its own one-off design.
+ *
+ * Spec behaviour preserved here:
+ *   - Renders only when there's a real change (`message` non-null —
+ *     the hook handles that gating via fingerprint diffing).
+ *   - Trigger fires on the next viewport entry after the message
+ *     lands, *not* on every render.
+ *   - Visible 4-5s, then fades out.
+ *
+ * @param {object} props
+ * @param {string|null} props.message  - the change message (null hides)
+ * @param {boolean} props.inView       - is the parent card in viewport?
+ * @param {"orange"|"elite"} [props.variant] - palette forwarded to
+ *                                       UpdateBanner. Default "orange"
+ *                                       preserves the original look;
+ *                                       the years card opts into
+ *                                       "elite" so the banner matches
+ *                                       its slate + gold treatment.
+ */
+export function ExperienceUpdateBanner({ message, inView, variant = "orange" }) {
+  const [shown, setShown] = useState(false);
+  // Remembers which message we've already played so re-entries with
+  // the same message don't re-show it. A new message coming in (the
+  // ref doesn't match) re-arms the trigger.
+  const lastPlayedRef = useRef(null);
+
+  useEffect(() => {
+    if (!message || !inView) return;
+    if (lastPlayedRef.current === message) return;
+    lastPlayedRef.current = message;
+    setShown(true);
+    const timer = setTimeout(() => setShown(false), VISIBLE_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [message, inView]);
+
+  return (
+    <UpdateBanner
+      message={shown ? message : null}
+      visible={shown}
+      srPrefix="Experience update: "
+      variant={variant}
+    />
+  );
+}

--- a/src/components/about/ItemsLayout.jsx
+++ b/src/components/about/ItemsLayout.jsx
@@ -1,22 +1,40 @@
 "use client";
 import { motion } from "framer-motion";
 import clsx from "clsx";
+import { forwardRef } from "react";
 
-const ItemLayout = ({ children, className }) => {
+// `forwardRef` + spread `...rest` so the years card on the about page
+// (and any future consumer) can attach an onClick/role/tabIndex/ref
+// without forking the layout. All existing call sites pass only
+// `className` and `children` and stay binary-compatible.
+const ItemLayout = forwardRef(function ItemLayout(
+  { children, className, ...rest },
+  ref,
+) {
   return (
     <motion.div
+      ref={ref}
       initial={{ scale: 0 }}
       whileInView={{ scale: 1 }}
       transition={{ duration: 0.5 }}
       viewport={{ once: false }}
+      // `space-y-8` was dead styling — every existing consumer wraps a
+      // single visible child so the inter-child margin never fired. It
+      // *did* fire on the years card after issue #17 added the
+      // ExperienceUpdateBanner as a second direct child (sr-only +
+      // banner overlay sibling to the h1), pushing the h1 2rem off
+      // the centered axis. Dropping the utility is a true no-op for
+      // every other ItemLayout instance and unbreaks the centering
+      // without per-consumer overrides.
       className={clsx(
-        "custom-bg-abt p-6 sm:p-8 rounded-xl flex items-center justify-center space-y-8",
+        "custom-bg-abt p-6 sm:p-8 rounded-xl flex items-center justify-center",
         className
       )}
+      {...rest}
     >
       {children}
     </motion.div>
   );
-};
+});
 
 export default ItemLayout;

--- a/src/components/about/LanguagesCard.jsx
+++ b/src/components/about/LanguagesCard.jsx
@@ -1,5 +1,7 @@
-import { motion, useInView, AnimatePresence } from "framer-motion";
+import { motion, useInView } from "framer-motion";
 import React, { useRef, useEffect, useState } from "react";
+
+import { UpdateBanner } from "./UpdateBanner";
 
 export default function LanguagesCard({ data, isUpdated }) {
     const cardRef = useRef(null);
@@ -15,21 +17,11 @@ export default function LanguagesCard({ data, isUpdated }) {
             transition={{ duration: 1, ease: "easeOut" }}
             className="p-5 w-full relative overflow-hidden h-full"
         >
-            {/* 🔥 Update Banner */}
-            <AnimatePresence>
-                {isUpdated && (
-                    <motion.div
-                        key="banner"
-                        initial={{ opacity: 0, y: -20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: -20 }}
-                        transition={{ duration: 0.4, ease: "easeOut" }}
-                        className="absolute inset-0 flex items-center justify-center bg-orange-500/80 backdrop-blur-xl text-[#ff6d05] font-medium text-lg md:text-xl rounded-lg z-10"
-                    >
-                        This table has been updated
-                    </motion.div>
-                )}
-            </AnimatePresence>
+            <UpdateBanner
+                message={isUpdated ? "This table has been updated" : null}
+                visible={isInView}
+                srPrefix="Languages update: "
+            />
 
             {/* Header */}
             <h2 className="text-xl md:text-2xl text-left w-full capitalize text-shadow-neon-orange mb-6">

--- a/src/components/about/RepoStatsCard.jsx
+++ b/src/components/about/RepoStatsCard.jsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { AnimatePresence, motion, useAnimation, useInView, useReducedMotion } from "framer-motion";
+import { motion, useAnimation, useInView, useReducedMotion } from "framer-motion";
+import { useViewportCountTrigger } from "@/hooks/useViewportCountTrigger";
+import { UpdateBanner } from "./UpdateBanner";
 import {
   Clock,
   GitCommitHorizontal,
@@ -85,7 +87,10 @@ function AnimatedTitle({ text, play }) {
   const prefersReducedMotion = useReducedMotion();
   if (prefersReducedMotion) {
     return (
-      <h3 className="text-xl font-semibold text-shadow-neon-orange break-words">
+      <h3
+        className="text-xl font-semibold break-words"
+        style={{ color: "#ff6d05", textShadow: "none" }}
+      >
         {text}
       </h3>
     );
@@ -111,7 +116,8 @@ function AnimatedTitle({ text, play }) {
       variants={container}
       initial="hidden"
       animate={play ? "visible" : "hidden"}
-      className="text-xl font-semibold text-shadow-neon-orange break-words"
+      className="text-xl font-semibold break-words"
+      style={{ color: "#ff6d05", textShadow: "none" }}
       aria-label={text}
     >
       {chars.map((c, i) => (
@@ -129,7 +135,7 @@ function AnimatedTitle({ text, play }) {
 }
 
 // ----- Single metric row: count-up + optional post-count pulse -----
-function MetricRow({ icon: Icon, label, value, isInView, isDate = false, pulseOnComplete = false, prefersReducedMotion = false }) {
+function MetricRow({ icon: Icon, label, value, playToken, isDate = false, pulseOnComplete = false, prefersReducedMotion = false }) {
   // When reduced motion is requested, initialize the display directly at the
   // target so the value reads instantly with no animated progression.
   const target = isDate ? value : Number(value) || 0;
@@ -156,8 +162,11 @@ function MetricRow({ icon: Icon, label, value, isInView, isDate = false, pulseOn
       setPulse(false);
       return;
     }
-    if (!isInView) {
-      setDisplay(0);
+    // Pre-trigger state: the hook hasn't seen a true viewport entry yet,
+    // so leave `display` at its initial 0 and wait. No reset on later
+    // viewport exits — the new playToken-driven contract holds the
+    // final value in place until the next *real* entry cycle.
+    if (playToken === 0) {
       setPulse(false);
       return;
     }
@@ -173,6 +182,13 @@ function MetricRow({ icon: Icon, label, value, isInView, isDate = false, pulseOn
       setPulse(false);
       return;
     }
+
+    // Snap to 0 before the first RAF frame so a re-entry trigger
+    // (display currently holding the previous final `target`) starts
+    // the count-up from 0 instead of flashing the final value for one
+    // frame. The initial-render case is a no-op because display is
+    // already 0.
+    setDisplay(0);
 
     let startTime = null;
     const tick = (ts) => {
@@ -190,7 +206,7 @@ function MetricRow({ icon: Icon, label, value, isInView, isDate = false, pulseOn
     return () => {
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
-  }, [isInView, target, isDate, value, pulseOnComplete, prefersReducedMotion]);
+  }, [playToken, target, isDate, value, pulseOnComplete, prefersReducedMotion]);
 
   return (
     <motion.div
@@ -198,7 +214,7 @@ function MetricRow({ icon: Icon, label, value, isInView, isDate = false, pulseOn
       // Hover transforms (`x: 5` slide, icon scale/rotate) are tiny but they
       // are still motion. Skip them when the user has opted out.
       whileHover={prefersReducedMotion ? undefined : { x: 5, transition: { duration: 0.18 } }}
-      className="flex items-center justify-between gap-2 w-full px-2 py-1 rounded-md hover:bg-orange-500/5 transition-colors"
+      className="flex items-center justify-between gap-2 w-full px-2 py-1 rounded-md hover:bg-[#ff6d05]/5 transition-colors"
     >
       <div className="flex items-center gap-2 min-w-0">
         <motion.span
@@ -206,10 +222,10 @@ function MetricRow({ icon: Icon, label, value, isInView, isDate = false, pulseOn
           transition={{ type: "spring", stiffness: 400 }}
           className="flex-shrink-0"
         >
-          <Icon className="w-4 h-4 text-amber-500" />
+          <Icon className="w-4 h-4" style={{ color: "#ffaa2a" }} />
         </motion.span>
         <span
-          className="text-xs sm:text-sm text-shadow-neon-light-orange truncate"
+          className="text-xs sm:text-sm truncate text-fire-amber"
           style={{ textShadow: "none" }}
         >
           {label}
@@ -218,7 +234,11 @@ function MetricRow({ icon: Icon, label, value, isInView, isDate = false, pulseOn
       <motion.span
         animate={pulse ? { scale: [1, 1.18, 1], transition: { duration: 0.4, ease: "easeOut" } } : { scale: 1 }}
         onAnimationComplete={() => pulse && setPulse(false)}
-        className="text-xs sm:text-sm font-semibold text-shadow-neon-orange tabular-nums whitespace-nowrap"
+        className="text-xs sm:text-sm font-semibold tabular-nums whitespace-nowrap"
+        style={{
+          color: "#ff6d05",
+          textShadow: "none",
+        }}
       >
         {/* `display` cycles through 0 → target during the count-up and is
             reset to 0 whenever the card scrolls out of view. Exposing that
@@ -235,7 +255,7 @@ function MetricRow({ icon: Icon, label, value, isInView, isDate = false, pulseOn
 }
 
 // ----- Activity score arc (SVG) -----
-function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion = false }) {
+function ActivityArc({ score, maxScore = 10000, playToken, prefersReducedMotion = false }) {
   const radius = 36;
   const circumference = 2 * Math.PI * radius;
   const controls = useAnimation();
@@ -259,7 +279,10 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
   // using the same easing the numeric counters use, so the arc and the number
   // inside it land together as a single elite gesture. Under reduced motion
   // the same final offset is set with `duration: 0`, so the arc paints in
-  // place without any sweep.
+  // place without any sweep. Otherwise we wait for a real viewport entry
+  // (`playToken > 0`) and snap back to `circumference` first so a re-entry
+  // trigger animates the sweep again from empty — without that the second
+  // play would have nothing to animate (already at `finalOffset`).
   useEffect(() => {
     if (prefersReducedMotion) {
       controls.start({
@@ -268,18 +291,13 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
       });
       return;
     }
-    if (isInView) {
-      controls.start({
-        strokeDashoffset: finalOffset,
-        transition: { duration: DURATION / 1000, ease: fastStartSlowFinish },
-      });
-    } else {
-      controls.start({
-        strokeDashoffset: circumference,
-        transition: { duration: 0.3 },
-      });
-    }
-  }, [isInView, finalOffset, circumference, controls, prefersReducedMotion]);
+    if (playToken === 0) return;
+    controls.set({ strokeDashoffset: circumference });
+    controls.start({
+      strokeDashoffset: finalOffset,
+      transition: { duration: DURATION / 1000, ease: fastStartSlowFinish },
+    });
+  }, [playToken, finalOffset, circumference, controls, prefersReducedMotion]);
 
   // Numeric count-up: identical sprint-then-settle behaviour as MetricRow.
   // Skipped entirely under reduced motion — the score reads as the final
@@ -291,10 +309,9 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
       setDisplayScore(target);
       return;
     }
-    if (!isInView) {
-      setDisplayScore(0);
-      return;
-    }
+    // Pre-trigger: stay at the initial 0 until the first real viewport
+    // entry. Holds value between true exits and re-entries (no reset).
+    if (playToken === 0) return;
     // Zero-target fast path — same rationale as MetricRow's: the easing
     // produces 0 every frame so the loop would just call setDisplayScore(0)
     // ~120 times across the full DURATION. The arc effect above also
@@ -304,6 +321,10 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
       setDisplayScore(0);
       return;
     }
+
+    // Snap to 0 before the first RAF frame so a re-entry trigger
+    // animates from 0 again instead of flashing the previous final.
+    setDisplayScore(0);
 
     let startTime = null;
     const tick = (ts) => {
@@ -320,7 +341,7 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
     return () => {
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
-  }, [isInView, target, prefersReducedMotion]);
+  }, [playToken, target, prefersReducedMotion]);
 
   return (
     <div className="flex flex-col items-center gap-1 flex-shrink-0">
@@ -360,7 +381,10 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
           />
         </svg>
         <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <span className="text-xs font-bold text-shadow-neon-orange leading-none tabular-nums">
+          <span
+            className="text-xs font-bold leading-none tabular-nums"
+            style={{ color: "#ff6d05", textShadow: "none" }}
+          >
             {/* Same accessibility split as MetricRow: `displayScore` cycles
                 through 0 → target and resets to 0 when out of view, so
                 exposing it to AT would announce "score 0" to keyboard /
@@ -372,7 +396,7 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
             <span aria-hidden="true">{displayScore.toLocaleString()}</span>
           </span>
           <span
-            className="text-[9px] text-shadow-neon-light-orange leading-none mt-0.5"
+            className="text-[9px] leading-none mt-0.5 text-fire-amber"
             style={{ textShadow: "none" }}
           >
             score
@@ -380,7 +404,7 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
         </div>
       </div>
       <span
-        className="text-[10px] text-shadow-neon-light-orange"
+        className="text-[10px] text-fire-amber"
         style={{ textShadow: "none" }}
       >
         Activity Score
@@ -392,9 +416,19 @@ function ActivityArc({ score, maxScore = 10000, isInView, prefersReducedMotion =
 // ----- Main card -----
 export default function ReadmeStatsCard({ data, isUpdated, diffMessage }) {
   const ref = useRef(null);
-  // `once: false` lets the count-ups and entrance animations replay on every
-  // scroll-in. `amount: 0.3` fires when ~30% of the card crosses the viewport.
-  const isInView = useInView(ref, { amount: 0.3, once: false });
+  // Two visibility signals, intentionally separated:
+  //   - `isInView` (raw observer) still drives the card's outer fade-in
+  //     variants, the AnimatedTitle's `play`, and the diff-message banner
+  //     gate — those should respond immediately to visibility flips.
+  //   - `playToken` (latched + hysteresis-debounced) drives the numeric
+  //     count-ups, so brief in/out scroll oscillations near the viewport
+  //     edge don't restart the animation mid-flight. Passed down to
+  //     MetricRow and ActivityArc; both depend on it instead of raw
+  //     `isInView` for their RAF loops. `amount: 0.3` fires when ~30% of
+  //     the card crosses the viewport.
+  const { isInView, playToken } = useViewportCountTrigger(ref, {
+    amount: 0.3,
+  });
   // Mirrors the CSS `prefers-reduced-motion` override in globals.css so the
   // decorative pulse on the language-color dot also holds still for users
   // who've opted out of motion.
@@ -434,70 +468,44 @@ export default function ReadmeStatsCard({ data, isUpdated, diffMessage }) {
       animate={isInView ? "visible" : "hidden"}
       className="repo-card-breathe w-full p-6 relative overflow-hidden rounded-lg"
     >
-      {/* Screen-reader announcer for diff updates. Always mounted (the
-          AnimatePresence overlay would unmount this before the SR finished
-          reading it) and intentionally NOT gated on `isInView` — the visual
-          overlay is, but assistive tech users navigate non-spatially and
-          should hear the update whether they've "scrolled" to the card or
-          not. `aria-live="polite"` queues the announcement to the next
-          idle moment, which is right for non-critical stat updates. */}
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {isUpdated && diffMessage ? `Repository update: ${diffMessage}` : ""}
-      </div>
-
-      <AnimatePresence>
-        {isUpdated && isInView && diffMessage && (
-          <motion.div
-            key="repo-banner"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.5, ease: "easeOut" }}
-            className="absolute inset-0 z-10 flex items-center justify-center rounded-lg overflow-hidden"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 50%, rgba(255,179,71,0.18) 0%, rgba(177,102,18,0.10) 35%, rgba(10,6,3,0.92) 75%)",
-              backdropFilter: "blur(16px) saturate(140%)",
-              WebkitBackdropFilter: "blur(16px) saturate(140%)",
-              boxShadow:
-                "inset 0 0 0 1px rgba(255,179,71,0.35), inset 0 0 40px rgba(255,109,5,0.08), 0 0 28px rgba(255,109,5,0.14)",
-            }}
-          >
-            <motion.span
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.12, ease: "easeOut" }}
-              className="font-medium text-lg md:text-xl tracking-wide text-center px-6"
-              style={{
-                color: "#ffb347",
-                textShadow:
-                  "0 0 4px rgba(255,176,58,0.65), 0 0 14px rgba(177,102,18,0.55), 0 0 28px rgba(255,109,5,0.18)",
-              }}
-            >
-              {diffMessage}
-            </motion.span>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <UpdateBanner
+        message={isUpdated && diffMessage ? diffMessage : null}
+        visible={isInView}
+        srPrefix="Repository update: "
+      />
 
       {/* Title + Most-Active badge */}
       <motion.div variants={childVariants} className="flex items-start justify-between gap-3 flex-wrap mb-3">
         <div className="flex items-center gap-2 min-w-0">
-          <Monitor className="w-5 h-5 text-amber-500 flex-shrink-0" />
+          <Monitor
+            className="w-5 h-5 flex-shrink-0"
+            style={{ color: "#ffaa2a" }}
+          />
           <AnimatedTitle text={name} play={isInView} />
         </div>
         <span
-          className="badge-shimmer relative text-shadow-neon-light-orange text-xs font-light px-2 py-0.5 border border-amber-500/40 rounded-full overflow-hidden whitespace-nowrap"
-          style={{ textShadow: "none" }}
+          // Eyebrow microlabel — same role as "CAREER SNAPSHOT" on the
+          // modal and "YEARS IN THE CRAFT" on the years card, so it
+          // takes the same eyebrow amber palette token.
+          // `badge-shimmer` paints its own moving gradient as the element
+          // background, which would override the fire-amber background-clip
+          // gradient if both lived on the same node. Keep the shimmer on
+          // the outer pill and apply `text-fire-amber` to an inner span so
+          // the text itself can still clip its own gradient.
+          className="badge-shimmer relative text-xs font-light px-2 py-0.5 rounded-full overflow-hidden whitespace-nowrap"
+          style={{
+            textShadow: "none",
+            border: "1px solid #ffaa2a",
+          }}
         >
-          Most Active Repository
+          <span className="text-fire-amber">Most Active Repository</span>
         </span>
       </motion.div>
 
       {/* Description */}
       <motion.p
         variants={childVariants}
-        className="text-sm text-shadow-neon-light-orange font-light mb-4"
+        className="text-sm font-light mb-4 text-fire-amber"
         style={{ textShadow: "none" }}
       >
         {description}
@@ -535,7 +543,7 @@ export default function ReadmeStatsCard({ data, isUpdated, diffMessage }) {
           }
         />
         <span
-          className="text-sm text-shadow-neon-light-orange font-light"
+          className="text-sm font-light text-fire-amber"
           style={{ textShadow: "none" }}
         >
           {language}
@@ -557,10 +565,10 @@ export default function ReadmeStatsCard({ data, isUpdated, diffMessage }) {
           className="flex flex-col gap-1 w-full sm:w-auto sm:flex-1 sm:min-w-[200px]"
         >
           {metrics.map((m) => (
-            <MetricRow key={m.label} {...m} isInView={isInView} prefersReducedMotion={prefersReducedMotion} />
+            <MetricRow key={m.label} {...m} playToken={playToken} prefersReducedMotion={prefersReducedMotion} />
           ))}
         </motion.div>
-        <ActivityArc score={activityScore} isInView={isInView} prefersReducedMotion={prefersReducedMotion} />
+        <ActivityArc score={activityScore} playToken={playToken} prefersReducedMotion={prefersReducedMotion} />
       </motion.div>
     </motion.div>
   );

--- a/src/components/about/StatsCard.jsx
+++ b/src/components/about/StatsCard.jsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { motion, useInView, useAnimation, AnimatePresence } from "framer-motion";
+import { motion, useInView, useAnimation } from "framer-motion";
 import { Star, Clock, GitBranch, AlertCircle, Package } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+
+import { UpdateBanner } from "./UpdateBanner";
 
 export default function GitHubStatsCard({ data, userName = "GitHub User", isUpdated }) {
     const cardRef = useRef(null);
@@ -24,22 +26,11 @@ export default function GitHubStatsCard({ data, userName = "GitHub User", isUpda
             transition={{ duration: 0.6, ease: "easeOut" }}
             className="p-5 w-full relative overflow-hidden"
         >
-            <AnimatePresence>
-                {isUpdated && (
-                    <motion.div
-                        key="banner"
-                        initial={{ opacity: 0, y: -20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: -20 }}
-                        transition={{ duration: 0.4, ease: "easeOut" }}
-                        className="absolute inset-0 flex items-center justify-center bg-orange-500/80 backdrop-blur-xl text-[#ff6d05] font-medium text-lg md:text-xl rounded-lg z-10"
-                    >
-                        <span className="">
-                            Data in this section has been updated
-                        </span>
-                    </motion.div>
-                )}
-            </AnimatePresence>
+            <UpdateBanner
+                message={isUpdated ? "Data in this section has been updated" : null}
+                visible={isInView}
+                srPrefix="Stats update: "
+            />
 
             <h2 className="text-xl md:text-2xl text-left w-full capitalize text-shadow-neon-orange mb-4">
                 {userName}&apos;s GitHub Stats
@@ -110,7 +101,7 @@ function AnimatedStat({ icon: Icon, label, value, delay, isInView }) {
             className="flex items-center gap-3 w-full justify-between"
         >
             <div className="flex items-center gap-2">
-                <Icon className="w-5 h-5 text-amber-500" />
+                <Icon className="w-5 h-5" style={{ color: "#ffaa2a" }} />
                 <span style={{ textShadow: "none" }} className=" text-xs md:text-base text-shadow-neon-light-orange">
                     {label}:
                 </span>

--- a/src/components/about/StreakStatsCard.jsx
+++ b/src/components/about/StreakStatsCard.jsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { AnimatePresence, motion, useInView } from "framer-motion";
+import { motion, useInView } from "framer-motion";
 import { Flame } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+
+import { UpdateBanner } from "./UpdateBanner";
 
 export default function StreakStatsCard({ data, isUpdated }) {
     const cardRef = useRef(null);
@@ -18,22 +20,11 @@ export default function StreakStatsCard({ data, isUpdated }) {
             transition={{ duration: 0.6, ease: "easeOut" }}
             className="w-full px-4 py-6 relative overflow-hidden"
         >
-            <AnimatePresence>
-                {isUpdated && (
-                    <motion.div
-                        key="banner"
-                        initial={{ opacity: 0, y: -20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: -20 }}
-                        transition={{ duration: 0.4, ease: "easeOut" }}
-                        className="absolute inset-0 flex items-center justify-center bg-orange-500/80 backdrop-blur-xl text-[#ff6d05] font-medium text-lg md:text-xl rounded-lg z-10"
-                    >
-                        <span className="">
-                            This streak data has been updated
-                        </span>
-                    </motion.div>
-                )}
-            </AnimatePresence>
+            <UpdateBanner
+                message={isUpdated ? "This streak data has been updated" : null}
+                visible={isInView}
+                srPrefix="Streaks update: "
+            />
             <div className="flex flex-col sm:flex-row items-center md:justify-between justify-center sm:gap-2 gap-4">
                 {/* Total Contributions */}
                 <AnimatedStatBlock
@@ -84,7 +75,7 @@ export default function StreakStatsCard({ data, isUpdated }) {
                             />
                         </svg>
                         <div className="flex items-center justify-center absolute top-1 -translate-y-1/2 left-1/2 -translate-x-1/2 bg-[#0F000F] px-1">
-                            <Flame size={24} fill="#ea580c" className="text-orange-600" />
+                            <Flame size={24} fill="#ffaa2a" style={{ color: "#ffaa2a" }} />
                         </div>
 
                         <AnimatedNumber

--- a/src/components/about/UpdateBanner.jsx
+++ b/src/components/about/UpdateBanner.jsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+// Visual variants. Each variant ships every token needed by the full
+// banner choreography (entrance flash, sweep, aurora drift, ember
+// sparks, box-shadow breath) so the orange and elite palettes can
+// diverge cleanly without grafting one onto the other at runtime.
+const VARIANT_STYLES = {
+  orange: {
+    background:
+      "radial-gradient(circle at 50% 50%, rgba(255,179,71,0.18) 0%, rgba(177,102,18,0.10) 35%, rgba(10,6,3,0.92) 75%)",
+    boxShadow:
+      "inset 0 0 0 1px rgba(255,179,71,0.35), inset 0 0 40px rgba(255,109,5,0.08), 0 0 28px rgba(255,109,5,0.14)",
+    boxShadowBright:
+      "inset 0 0 0 1px rgba(255,209,120,0.65), inset 0 0 70px rgba(255,109,5,0.2), 0 0 56px rgba(255,109,5,0.36)",
+    flashCenter: "rgba(255, 220, 130, 0.75)",
+    flashMid: "rgba(255, 109, 5, 0.22)",
+    shimmer: "rgba(255, 220, 130, 0.6)",
+    aurora:
+      "radial-gradient(ellipse 80% 60% at 50% 50%, rgba(255,179,71,0.32) 0%, rgba(255,109,5,0.10) 40%, transparent 75%)",
+    emberColor: "#ffd27d",
+    emberShadow:
+      "0 0 6px rgba(255, 210, 125, 0.95), 0 0 14px rgba(255, 170, 42, 0.55)",
+  },
+  elite: {
+    background:
+      "radial-gradient(circle at 50% 50%, rgba(244,227,184,0.18) 0%, rgba(212,175,122,0.10) 35%, rgba(2,6,23,0.95) 75%)",
+    boxShadow:
+      "inset 0 0 0 1px rgba(244,227,184,0.4), inset 0 0 40px rgba(212,175,122,0.08), 0 0 28px rgba(212,175,122,0.2)",
+    boxShadowBright:
+      "inset 0 0 0 1px rgba(244,227,184,0.75), inset 0 0 70px rgba(212,175,122,0.22), 0 0 56px rgba(212,175,122,0.5)",
+    flashCenter: "rgba(244, 227, 184, 0.75)",
+    flashMid: "rgba(212, 175, 122, 0.22)",
+    shimmer: "rgba(244, 227, 184, 0.6)",
+    aurora:
+      "radial-gradient(ellipse 80% 60% at 50% 50%, rgba(244,227,184,0.32) 0%, rgba(212,175,122,0.10) 40%, transparent 75%)",
+    emberColor: "#f4e3b8",
+    emberShadow:
+      "0 0 6px rgba(244, 227, 184, 0.95), 0 0 14px rgba(212, 175, 122, 0.55)",
+  },
+};
+
+// Stagger choreography — every duration / delay lives here so the
+// banner's "shape" can be retuned without hunting through six
+// motion.span blocks. Times are in seconds.
+const TIMING = {
+  containerSpring: { type: "spring", stiffness: 200, damping: 26 },
+  containerOpacity: { duration: 0.5, ease: [0.22, 1, 0.36, 1] },
+  flash: { duration: 0.95, ease: [0.22, 1, 0.36, 1] },
+  shimmer: { duration: 1.8, delay: 0.45, ease: "easeInOut" },
+  auroraFade: { duration: 0.8, ease: [0.22, 1, 0.36, 1] },
+  auroraDrift: { duration: 9, repeat: Infinity, ease: "easeInOut" },
+  textStagger: 0.028,
+  textDelay: 0.55,
+  charDuration: 0.7,
+  boxBreath: {
+    duration: 3.8,
+    delay: 1.4,
+    repeat: Infinity,
+    ease: "easeInOut",
+    times: [0, 0.5, 1],
+  },
+};
+
+const SMOOTH_OUT = [0.22, 1, 0.36, 1];
+
+// Pre-randomized ember trajectories so each remount looks alive but is
+// deterministic across renders (no useEffect / Math.random in render).
+const EMBERS = [
+  { left: "10%", delay: 0.7, duration: 2.4, drift: 8, size: 3 },
+  { left: "25%", delay: 1.2, duration: 2.8, drift: -6, size: 2 },
+  { left: "42%", delay: 0.95, duration: 2.6, drift: 11, size: 3 },
+  { left: "58%", delay: 1.45, duration: 2.5, drift: -9, size: 2 },
+  { left: "74%", delay: 0.8, duration: 2.7, drift: 7, size: 3 },
+  { left: "88%", delay: 1.3, duration: 2.3, drift: -7, size: 2 },
+];
+
+// Continuously rising warm sparks. Each ember starts at the bottom
+// of the banner, drifts up and slightly sideways, fades and shrinks
+// as it rises, then loops. The `repeatDelay` keeps re-emissions from
+// landing exactly in phase so the field feels organic, not pulsed.
+function EmberLayer({ emberColor, emberShadow }) {
+  return (
+    <div className="absolute inset-0 pointer-events-none overflow-hidden">
+      {EMBERS.map((e, i) => (
+        <motion.span
+          key={i}
+          aria-hidden="true"
+          className="absolute rounded-full"
+          style={{
+            left: e.left,
+            bottom: "-6px",
+            width: `${e.size}px`,
+            height: `${e.size}px`,
+            background: emberColor,
+            boxShadow: emberShadow,
+          }}
+          initial={{ opacity: 0, y: 0, scale: 0 }}
+          animate={{
+            opacity: [0, 0.95, 0.75, 0],
+            y: [0, -22, -52, -88],
+            x: [0, e.drift * 0.35, e.drift * 0.75, e.drift],
+            scale: [0, 1, 0.95, 0.35],
+          }}
+          transition={{
+            duration: e.duration,
+            delay: e.delay,
+            repeat: Infinity,
+            repeatDelay: 0.35,
+            ease: "easeOut",
+            times: [0, 0.2, 0.6, 1],
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// Per-character text reveal. Each character is its own motion.span
+// with `text-fire-amber` applied individually so it carries the warm
+// gradient fill, then blurs + lifts + scales in with a stagger so the
+// message reads like it's being written by a wand of light. The
+// parent carries `aria-label={message}` and every char span is
+// `aria-hidden`, so assistive tech still hears the message once,
+// cleanly.
+function AnimatedMessage({ message, prefersReducedMotion }) {
+  if (prefersReducedMotion) {
+    return (
+      <span className="relative z-10 font-medium text-lg md:text-xl tracking-wide text-center px-6 text-fire-amber">
+        {message}
+      </span>
+    );
+  }
+  const chars = Array.from(message);
+  const container = {
+    hidden: {},
+    visible: {
+      transition: {
+        staggerChildren: TIMING.textStagger,
+        delayChildren: TIMING.textDelay,
+      },
+    },
+    exit: {
+      transition: { staggerChildren: 0.012, staggerDirection: -1 },
+    },
+  };
+  const charVariant = {
+    hidden: { opacity: 0, y: 14, filter: "blur(10px)", scale: 0.92 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      filter: "blur(0px)",
+      scale: 1,
+      transition: { duration: TIMING.charDuration, ease: SMOOTH_OUT },
+    },
+    exit: {
+      opacity: 0,
+      y: -6,
+      filter: "blur(6px)",
+      transition: { duration: 0.3, ease: "easeIn" },
+    },
+  };
+  return (
+    <motion.span
+      variants={container}
+      initial="hidden"
+      animate="visible"
+      exit="exit"
+      className="relative z-10 font-medium text-lg md:text-xl tracking-wide text-center px-6 whitespace-nowrap"
+      aria-label={message}
+    >
+      {chars.map((c, i) => (
+        <motion.span
+          key={i}
+          variants={charVariant}
+          aria-hidden="true"
+          className="inline-block text-fire-amber"
+          style={{ whiteSpace: "pre" }}
+        >
+          {c === " " ? " " : c}
+        </motion.span>
+      ))}
+    </motion.span>
+  );
+}
+
+// Shared "this card just changed" overlay. Six visual layers stacked
+// back-to-front:
+//
+//   1. Backdrop blur + radial ambient gradient (resting surface)
+//   2. Aurora ribbon — slow horizontal drift, ambient life
+//   3. Pinprick flash — pinprick of warm light blooms on entrance
+//   4. Shimmer sweep — single diagonal pass, like light on a bevel
+//   5. Embers — continuously rising warm sparks
+//   6. Per-character text reveal — message written by stagger
+//
+// Sustain: box-shadow slowly breathes, aurora keeps drifting,
+// embers keep rising — the banner stays alive instead of going
+// static after entrance. Exit: container fade + scale, chars
+// dissolve back out in reverse stagger order.
+//
+// Anchor parent must be `position: relative` (caller's responsibility)
+// — every existing consumer in the about-page cards already is.
+//
+// @param {object} props
+// @param {string|null} props.message - the change message; null/empty hides
+// @param {boolean} props.visible     - render visual overlay this paint?
+// @param {string} [props.srPrefix]   - prefix for the SR announcement
+// @param {"orange"|"elite"} [props.variant] - visual palette
+export function UpdateBanner({ message, visible, srPrefix = "", variant = "orange" }) {
+  const prefersReducedMotion = useReducedMotion();
+  const showVisual = Boolean(visible && message);
+  const palette = VARIANT_STYLES[variant] ?? VARIANT_STYLES.orange;
+
+  const containerInitial = prefersReducedMotion
+    ? { opacity: 0 }
+    : { opacity: 0, scale: 0.93 };
+  const containerAnimate = prefersReducedMotion
+    ? { opacity: 1 }
+    : {
+        opacity: 1,
+        scale: 1,
+        boxShadow: [
+          palette.boxShadow,
+          palette.boxShadowBright,
+          palette.boxShadow,
+        ],
+      };
+  const containerExit = prefersReducedMotion
+    ? { opacity: 0 }
+    : { opacity: 0, scale: 0.97 };
+
+  const containerTransition = prefersReducedMotion
+    ? { duration: 0.4 }
+    : {
+        ...TIMING.containerSpring,
+        opacity: TIMING.containerOpacity,
+        boxShadow: TIMING.boxBreath,
+      };
+
+  return (
+    <>
+      {/* SR announcer is always mounted. Wrapping in AnimatePresence
+          would unmount the node before the polite live region had
+          time to announce on transition, swallowing the message. */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {message ? `${srPrefix}${message}` : ""}
+      </div>
+
+      <AnimatePresence>
+        {showVisual && (
+          <motion.div
+            key="update-banner"
+            initial={containerInitial}
+            animate={containerAnimate}
+            exit={containerExit}
+            transition={containerTransition}
+            // pointer-events-none so the banner overlay doesn't
+            // swallow clicks on the card beneath (e.g. the years card
+            // opens a modal on click — the banner shouldn't block it).
+            className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none rounded-lg overflow-hidden"
+            style={{
+              background: palette.background,
+              backdropFilter: "blur(16px) saturate(140%)",
+              WebkitBackdropFilter: "blur(16px) saturate(140%)",
+            }}
+          >
+            {!prefersReducedMotion && (
+              <>
+                {/* Layer 2 — Aurora ribbon drifting behind everything */}
+                <motion.span
+                  aria-hidden="true"
+                  className="absolute inset-0"
+                  initial={{ opacity: 0, x: "-15%" }}
+                  animate={{
+                    opacity: [0, 0.95, 0.75, 0.95, 0.75],
+                    x: ["-15%", "15%", "-10%", "12%", "-15%"],
+                  }}
+                  transition={{
+                    opacity: TIMING.auroraFade,
+                    x: TIMING.auroraDrift,
+                  }}
+                  style={{
+                    background: palette.aurora,
+                    filter: "blur(10px)",
+                  }}
+                />
+
+                {/* Layer 3 — Radial pinprick flash on entrance */}
+                <motion.span
+                  aria-hidden="true"
+                  className="absolute inset-0 rounded-lg"
+                  initial={{ opacity: 0.9, scale: 0 }}
+                  animate={{ opacity: 0, scale: 1.6 }}
+                  transition={TIMING.flash}
+                  style={{
+                    background: `radial-gradient(circle at 50% 50%, ${palette.flashCenter} 0%, ${palette.flashMid} 35%, transparent 70%)`,
+                    mixBlendMode: "screen",
+                  }}
+                />
+
+                {/* Layer 4 — Single-pass shimmer sweep */}
+                <motion.span
+                  aria-hidden="true"
+                  className="absolute inset-y-0 w-[60%]"
+                  initial={{ x: "-180%" }}
+                  animate={{ x: "260%" }}
+                  transition={TIMING.shimmer}
+                  style={{
+                    background: `linear-gradient(105deg, transparent 30%, ${palette.shimmer} 50%, transparent 70%)`,
+                    mixBlendMode: "screen",
+                  }}
+                />
+
+                {/* Layer 5 — Rising warm embers (continuous) */}
+                <EmberLayer
+                  emberColor={palette.emberColor}
+                  emberShadow={palette.emberShadow}
+                />
+              </>
+            )}
+
+            {/* Layer 6 — Per-character text reveal */}
+            <AnimatedMessage
+              message={message}
+              prefersReducedMotion={prefersReducedMotion}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/components/about/UpdateBanner.jsx
+++ b/src/components/about/UpdateBanner.jsx
@@ -241,9 +241,17 @@ export function UpdateBanner({ message, visible, srPrefix = "", variant = "orang
 
   return (
     <>
-      {/* SR announcer is always mounted. Wrapping in AnimatePresence
-          would unmount the node before the polite live region had
-          time to announce on transition, swallowing the message. */}
+      {/* SR announcer is always mounted, and its text is gated on
+          `message` ONLY — intentionally NOT on `visible` / `showVisual`.
+          AT users navigate by structure, not by viewport scrolling, so
+          they shouldn't be forced to find a card before hearing that
+          it changed. The `polite` live region queues the announcement
+          to fire after the user's current speech finishes, which is
+          the right cadence for a background data update. Wrapping in
+          AnimatePresence would also unmount the node before the live
+          region had time to announce on transition, swallowing the
+          message — another reason this sits outside the AnimatePresence
+          block below. */}
       <div className="sr-only" aria-live="polite" aria-atomic="true">
         {message ? `${srPrefix}${message}` : ""}
       </div>

--- a/src/components/about/UpdateBanner.jsx
+++ b/src/components/about/UpdateBanner.jsx
@@ -167,20 +167,28 @@ function AnimatedMessage({ message, prefersReducedMotion }) {
       initial="hidden"
       animate="visible"
       exit="exit"
-      className="relative z-10 font-medium text-lg md:text-xl tracking-wide text-center px-6 whitespace-nowrap"
+      className="relative z-10 inline-block max-w-full font-medium text-lg md:text-xl tracking-wide text-center px-6 break-words"
       aria-label={message}
     >
-      {chars.map((c, i) => (
-        <motion.span
-          key={i}
-          variants={charVariant}
-          aria-hidden="true"
-          className="inline-block text-fire-amber"
-          style={{ whiteSpace: "pre" }}
-        >
-          {c === " " ? " " : c}
-        </motion.span>
-      ))}
+      {chars.map((c, i) => {
+        // Space chars are invisible — drop the motion wrapper so they
+        // render as plain text nodes, which restores their role as the
+        // default line-break opportunity. The previous shape wrapped
+        // every space in an inline-block, which let the parent's
+        // (now removed) `whitespace-nowrap` keep the whole message on
+        // one line and overflow long sentences into `overflow-hidden`.
+        if (c === " ") return " ";
+        return (
+          <motion.span
+            key={i}
+            variants={charVariant}
+            aria-hidden="true"
+            className="inline-block text-fire-amber"
+          >
+            {c}
+          </motion.span>
+        );
+      })}
     </motion.span>
   );
 }

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -8,6 +8,11 @@ import StreakStatsCard from "./StreakStatsCard";
 import ReadmeStatsCard from "./RepoStatsCard";
 import { detectChanges } from "@/utils/diffChanges";
 import { computeRepoDiff } from "@/utils/repoDiff";
+import { useExperienceSummary } from "@/hooks/useExperienceSummary";
+import { useViewportCountTrigger } from "@/hooks/useViewportCountTrigger";
+import { ExperienceBreakdownModal } from "./ExperienceBreakdownModal";
+import { ExperienceUpdateBanner } from "./ExperienceUpdateBanner";
+import { UpdateBanner } from "./UpdateBanner";
 
 const githubStatsStorageKey = (username) =>
   `github-stats:lastGood:${username}`;
@@ -24,16 +29,140 @@ const RevealWord = ({ children, progress, range, reducedMotion }) => {
   );
 };
 
+// Inline percentage count-up. Mirrors the years card's primary
+// Counter — same viewport-trigger hook so the percentage tick begins
+// the moment the card enters view (and replays on re-entry), same
+// `animate()` driver from framer-motion. Renders as an inline-flex
+// span so it slots into the legend line without breaking the flex
+// row's alignment. Reduced motion shows the final value immediately.
+function PercentCount({ value }) {
+  const nodeRef = useRef(null);
+  const sectionRef = useRef(null);
+  const prefersReducedMotion = useReducedMotion();
+  const { playToken } = useViewportCountTrigger(sectionRef, { amount: 0.3 });
+
+  useEffect(() => {
+    const node = nodeRef.current;
+    if (!node) return;
+    if (prefersReducedMotion) {
+      node.textContent = String(value);
+      return;
+    }
+    if (playToken === 0) return;
+    const controls = animate(0, value, {
+      duration: 2,
+      onUpdate(v) {
+        node.textContent = v.toFixed(0);
+      },
+    });
+    return () => controls.stop();
+  }, [value, playToken, prefersReducedMotion]);
+
+  return (
+    <span ref={sectionRef} className="inline-flex items-baseline">
+      <span ref={nodeRef}>{prefersReducedMotion ? value : 0}</span>
+      <span>%</span>
+    </span>
+  );
+}
+
+// Two-segment proportional bar shown under the years digit on the
+// years card. Personal Projects on the left (gold), Employment on the
+// right (cool cyan) — same color encoding as the modal donut so the
+// two surfaces read as a single visual system. Segments are absolute-
+// positioned tooltips rather than children of a flex so a 0%-share
+// segment doesn't claim layout width.
+function ExperienceSplitBar({ personalMonths, employmentMonths }) {
+  const prefersReducedMotion = useReducedMotion();
+  const total = personalMonths + employmentMonths;
+  if (total === 0) return null;
+  const personalPct = (personalMonths / total) * 100;
+  const employmentPct = (employmentMonths / total) * 100;
+
+  return (
+    <div className="mt-4 w-full" aria-hidden="true">
+      <div
+        className="h-1.5 w-full rounded-full overflow-hidden relative"
+        style={{ background: "rgba(244, 227, 184, 0.06)" }}
+      >
+        <motion.span
+          className="absolute inset-y-0 left-0"
+          style={{
+            background: "#ff6d05",
+            boxShadow: "0 0 10px rgba(255, 109, 5, 0.45)",
+          }}
+          initial={prefersReducedMotion ? { width: `${personalPct}%` } : { width: 0 }}
+          whileInView={{ width: `${personalPct}%` }}
+          viewport={{ once: false, amount: 0.5 }}
+          transition={{ duration: 1, ease: "easeOut", delay: 0.2 }}
+        />
+        <motion.span
+          className="absolute inset-y-0"
+          style={{
+            left: `${personalPct}%`,
+            background: "#ffd27d",
+            boxShadow: "0 0 10px rgba(255, 210, 125, 0.45)",
+          }}
+          initial={prefersReducedMotion ? { width: `${employmentPct}%` } : { width: 0 }}
+          whileInView={{ width: `${employmentPct}%` }}
+          viewport={{ once: false, amount: 0.5 }}
+          transition={{ duration: 1, ease: "easeOut", delay: 0.4 }}
+        />
+      </div>
+      {/* Stacked legend — two rows of [dot label … percentage]. The
+          previous single-row `justify-between` layout cramped the
+          two pills on narrow card widths (years card is full-width
+          on mobile, 1/3 width at lg+; both can hit widths where
+          "● PERSONAL 32%" + "EMPLOYMENT 68% ●" overflowed or
+          wrapped awkwardly). Stacking is cleaner at every width and
+          aligns the percentages in a true vertical column thanks to
+          tabular-nums + justify-between on each row. */}
+      <div
+        className="flex flex-col gap-1 text-[10px] uppercase tracking-[0.16em] mt-2 tabular-nums"
+        style={{ color: "#d4af7a" }}
+      >
+        <span className="flex items-center justify-between gap-2">
+          <span className="flex items-center gap-1.5">
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+              style={{ background: "#ff6d05" }}
+            />
+            <span className="text-fire-amber">Personal</span>
+          </span>
+          <span style={{ color: "#ff6d05", textShadow: "none" }}>
+            <PercentCount value={Math.round(personalPct)} />
+          </span>
+        </span>
+        <span className="flex items-center justify-between gap-2">
+          <span className="flex items-center gap-1.5">
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+              style={{ background: "#ffd27d" }}
+            />
+            <span className="text-fire-amber">Employment</span>
+          </span>
+          <span style={{ color: "#ff6d05", textShadow: "none" }}>
+            <PercentCount value={Math.round(employmentPct)} />
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
 const AboutDetails = () => {
   // GitHub Username — override via NEXT_PUBLIC_GITHUB_USERNAME when forking.
   // The most-active repo is now picked server-side by /api/github-stats, so the
   // hardcoded `repo` constant that used to live here is gone (issue #22).
   const username = process.env.NEXT_PUBLIC_GITHUB_USERNAME || "MA1002643";
 
-  const [years, setYears] = useState(0);
   const [githubStats, setGithubStats] = useState(null)
   const [changedFields, setChangedFields] = useState([]);
   const [repoDiffMessage, setRepoDiffMessage] = useState(null);
+  // Dev-only override so a synthetic Shift+B can fire the experience
+  // banner, which is otherwise driven entirely by the hook. Stays null
+  // in production builds because the listener that sets it never runs.
+  const [testExperienceMessage, setTestExperienceMessage] = useState(null);
 
   // Scroll-linked per-word reveal for the "Architect of Enchantment" paragraph.
   // Both ends of the active scroll range are derived from the paragraph's own
@@ -77,16 +206,23 @@ const AboutDetails = () => {
   );
 
   // Counter Animation...
+  // Replays the count-up only on real viewport entries (and on `to`
+  // changes from upstream data). `useViewportCountTrigger` absorbs
+  // brief intersection-observer flicker at the viewport edge so a
+  // small scroll oscillation can't restart the animation mid-flight —
+  // same shared trigger now used by RepoStatsCard's MetricRow.
   function Counter({ from, to, plusIcon = true }) {
     const nodeRef = useRef(null);
     const sectionRef = useRef(null);
-    const isInView = useInView(sectionRef, { once: false, amount: 0.3 });
-    // `once: false` → triggers every time it's visible
-    // `amount: 0.3` → starts when 30% of the section is visible
+    const { playToken } = useViewportCountTrigger(sectionRef, { amount: 0.3 });
 
     useEffect(() => {
-      if (!isInView) return; // only run animation when visible
+      // Pre-trigger: leave the node empty; the count-up will populate
+      // it on the first real entry. No reset on exit — the value
+      // holds until the next real entry cycle.
+      if (playToken === 0) return;
       const node = nodeRef.current;
+      if (!node) return;
 
       const controls = animate(from, to, {
         duration: 2,
@@ -96,7 +232,7 @@ const AboutDetails = () => {
       });
 
       return () => controls.stop();
-    }, [from, to, isInView]);
+    }, [from, to, playToken]);
 
     return (
       <div ref={sectionRef} className="flex items-center justify-center">
@@ -106,39 +242,54 @@ const AboutDetails = () => {
     );
   }
 
-  // Set your desired start date here
-  const startDate = '2021-01-01T00:00:00';
+  // Issue #17: years is now driven by the experience-summary API
+  // (GitHub earliest-repo date + software roles parsed from the resume
+  // PDF) instead of a hardcoded `startDate`. The hook fetches once per
+  // mount; the server caches the underlying GitHub + PDF work for 24h
+  // so this is nearly free across visits. Defaulting `data` to null
+  // until the fetch resolves; the Counter below treats `null` as 0 and
+  // animates up once the real value lands.
+  const { data: experienceData, changeMessage: experienceChangeMessage } =
+    useExperienceSummary(username);
+  const experienceTotalMonths = experienceData?.total?.months ?? 0;
+  // Display unit follows the spec: years when total >= 12 months, else
+  // months. Both the numeric `to` and the trailing label switch
+  // together so they can't drift out of sync.
+  const experienceCounterValue =
+    experienceTotalMonths >= 12
+      ? Math.floor(experienceTotalMonths / 12)
+      : experienceTotalMonths;
+  const experienceCounterUnit =
+    experienceTotalMonths >= 12 ? "years" : "months";
 
-  useEffect(() => {
-    const calculateYears = () => {
-      const start = new Date(startDate);
-      const now = new Date();
-      const differenceInMs = now.getTime() - start.getTime();
-      const yearsElapsed = differenceInMs / (1000 * 60 * 60 * 24 * 365.25);
-      const newYears = Math.floor(yearsElapsed);
+  // Years-card-as-button: click / Enter / Space opens the breakdown
+  // modal. `experienceTriggerRef` lets the modal return focus to the
+  // card on close, matching the WAI-ARIA dialog focus-restoration
+  // pattern. Modal state lives here (not in the card subtree) because
+  // the modal is rendered at the end of the component tree as a fixed
+  // overlay — same z-index regardless of which card opened it.
+  const [isExperienceModalOpen, setIsExperienceModalOpen] = useState(false);
+  const experienceTriggerRef = useRef(null);
+  // Banner visibility driver. The banner component dedupes per
+  // message internally, so re-entering the card while the same
+  // message is "in flight" won't restart the timer; only a fresh
+  // change-message from the next poll will fire it again.
+  const isExperienceCardInView = useInView(experienceTriggerRef, {
+    once: false,
+    amount: 0.5,
+  });
+  const openExperienceModal = () => {
+    if (experienceData) setIsExperienceModalOpen(true);
+  };
+  const handleExperienceTriggerKeyDown = (e) => {
+    // Standard button keyboard semantics — Enter or Space activates.
+    // Prevent Space from scrolling the page.
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      openExperienceModal();
+    }
+  };
 
-      // Use functional state update to avoid stale closure
-      setYears(prevYears => {
-        if (prevYears && prevYears !== newYears) {
-          // Only push 'years' change if the value actually updated
-          setChangedFields(prev => {
-            if (!prev.includes("years")) {
-              return [...prev, "years"];
-            }
-            return prev;
-          });
-        }
-        return newYears;
-      });
-    };
-
-    // Run once immediately
-    calculateYears();
-
-    // Keep recalculating
-    const intervalId = setInterval(calculateYears, 20000);
-    return () => clearInterval(intervalId);
-  }, [startDate]);
 
 
   const getGithubStats = async () => {
@@ -339,11 +490,57 @@ const AboutDetails = () => {
       const timer = setTimeout(() => {
         setChangedFields([]);
         setRepoDiffMessage(null);
+        setTestExperienceMessage(null);
       }, 10000);
       return () => clearTimeout(timer);
     }
   }, [changedFields]);
 
+  // Dev-only banner sandbox. Press Shift+B anywhere on the page to push
+  // a synthetic change to every card on the about page at once — repo,
+  // stats, streaks, languages, skills section overlay, and the
+  // experience banner inside the years card. Same auto-dismiss path as
+  // a real API change (10s) so the harness clears itself.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+    console.log("[banner-sandbox] listener attached — press Shift+B to fire");
+    const handler = (e) => {
+      // `e.code` matches the physical key regardless of layout / caps,
+      // so this works on every Mac keyboard.
+      if (!e.shiftKey || e.code !== "KeyB") return;
+      const target = e.target;
+      // Don't hijack the chord while typing in a form field.
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      console.log("[banner-sandbox] firing all banners");
+      setChangedFields([
+        "languages",
+        "stats.stats",
+        "stats.user",
+        "stats.streaks",
+        "stats.repo",
+        "skills",
+      ]);
+      setRepoDiffMessage("Test: repository update banner");
+      setTestExperienceMessage("Test: experience update banner");
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+
+  // Skills icon-grid card needs the same in-view gating as every
+  // other card so the shared UpdateBanner only paints while the
+  // section is on screen (matching LanguagesCard, RepoStatsCard, etc.).
+  const skillsRef = useRef(null);
+  const isSkillsInView = useInView(skillsRef, { once: false, amount: 0.3 });
 
   //
   //
@@ -361,13 +558,22 @@ const AboutDetails = () => {
       <div className="grid grid-cols-12 gap-4 xs:gap-6 md:gap-8 w-full">
         <ItemLayout
           className={
-            " col-span-full lg:col-span-8 row-span-2 flex-col items-start"
+            // `!py-4 sm:!py-5` overrides the shared p-6/p-8 vertical
+            // padding to tighten the gap above the heading and below
+            // the paragraph (per the request — the card had "too
+            // much space on top and at the end"). `!` is needed
+            // because both rules target padding on the same element.
+            " col-span-full lg:col-span-8 row-span-2 flex-col items-start !py-4 sm:!py-5"
           }
         >
           <h2
-            className="text-xl md:text-2xl text-left w-full capitalize"
+            className="text-xl md:text-2xl text-left w-full capitalize mb-3"
             style={{
-              color: '#ffb347',
+              // Matches the "YEARS IN THE CRAFT" eyebrow on the years
+              // card (eyebrow amber from the 5-tone warm palette) so
+              // every uppercase / heading microlabel on the about
+              // page now reads in the same hue.
+              color: '#ffaa2a',
               textShadow: 'none',
               WebkitFontSmoothing: 'antialiased',
               MozOsxFontSmoothing: 'grayscale',
@@ -378,8 +584,7 @@ const AboutDetails = () => {
           </h2>
           <p
             ref={paragraphRef}
-            style={{ textShadow: "none" }}
-            className="font-light text-xs sm:text-sm md:text-base text-shadow-neon-light-orange"
+            className="font-light text-xs sm:text-sm md:text-base text-fire-amber"
           >
             {ARCHITECT_WORDS.map((word, i) => (
               <RevealWord
@@ -404,28 +609,73 @@ const AboutDetails = () => {
         </ItemLayout>
 
         <ItemLayout
-          className={"col-span-full xs:col-span-6 lg:col-span-4 text-accent"}
+          ref={experienceTriggerRef}
+          role="button"
+          tabIndex={experienceData ? 0 : -1}
+          aria-haspopup="dialog"
+          aria-expanded={isExperienceModalOpen}
+          aria-label={
+            experienceData
+              ? `${experienceCounterValue}+ ${experienceCounterUnit} of experience. Activate to open category breakdown.`
+              : "Loading experience summary"
+          }
+          onClick={openExperienceModal}
+          onKeyDown={handleExperienceTriggerKeyDown}
+          className={`group relative col-span-full xs:col-span-6 lg:col-span-4 text-accent flex-col !items-stretch !justify-center ${
+            experienceData ? "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/50" : "cursor-default"
+          }`}
         >
-          <AnimatePresence>
-            {changedFields.includes('years') && (
-              <motion.div
-                key="banner"
-                initial={{ opacity: 0, y: -20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -20 }}
-                transition={{ duration: 0.4, ease: "easeOut" }}
-                className="absolute inset-0 flex items-center justify-center bg-orange-500/80 backdrop-blur-xl text-[#ff6d05] font-medium text-lg md:text-xl rounded-lg z-10"
-              >
-                <span className="">
-                  Years of experience number has been changed
-                </span>
-              </motion.div>
-            )}
-          </AnimatePresence>
-          <h1 className="flex items-center gap-2  font-semibold w-full text-left text-2xl sm:text-5xl text-shadow-neon-orange">
-            <Counter from={0} to={years}></Counter>
-            <p style={{ textShadow: "none" }} className="font-semibold text-base text-shadow-neon-light-orange">years of experience</p>
+          <ExperienceUpdateBanner
+            message={testExperienceMessage ?? experienceChangeMessage}
+            inView={isExperienceCardInView}
+            variant="elite"
+          />
+
+          {/* Eyebrow — uppercase micro-label sets the "feature card"
+              tone before the eye lands on the digit. Amber tone reads
+              a touch warmer than the digit's vivid orange below it. */}
+          <p
+            aria-hidden="true"
+            className="text-[10px] uppercase tracking-[0.22em] mb-2"
+            style={{ color: "#ffaa2a", textShadow: "none" }}
+          >
+            Years in the craft
+          </p>
+
+          <h1
+            className="flex items-baseline gap-2 font-semibold w-full text-left text-2xl sm:text-5xl"
+            style={{ color: "#ff6d05", textShadow: "none" }}
+          >
+            <Counter from={0} to={experienceCounterValue}></Counter>
+            <p
+              className="font-semibold text-base text-fire-amber"
+              style={{ textShadow: "none" }}
+            >
+              {experienceCounterUnit} of experience
+            </p>
           </h1>
+
+          {/* Two-segment split bar — Personal vs Employment as a share
+              of total. Only renders when we have data (otherwise the
+              segments would both compute to NaN). */}
+          {experienceData && experienceTotalMonths > 0 && (
+            <ExperienceSplitBar
+              personalMonths={experienceData?.personalProjects?.months ?? 0}
+              employmentMonths={experienceData?.employment?.months ?? 0}
+            />
+          )}
+
+          {/* Hover affordance — fades in on group-hover/focus so the
+              click target stops being implicit. `aria-hidden` because
+              the card itself already advertises `role="button"` +
+              aria-haspopup, so this is purely a visual hint. */}
+          <p
+            aria-hidden="true"
+            className="text-[11px] tracking-wide mt-3 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300"
+            style={{ color: "#ffd27d", textShadow: "none" }}
+          >
+            View breakdown →
+          </p>
         </ItemLayout>
 
         {githubStats?.languages && <ItemLayout
@@ -438,23 +688,15 @@ const AboutDetails = () => {
           <GitHubStatsCard data={githubStats.stats.stats} userName={githubStats.stats.user.name} isUpdated={changedFields.includes("stats.stats") || changedFields.includes('stats.user')} />
         </ItemLayout>}
 
-        <ItemLayout className="col-span-full grid grid-cols-4 sm:grid-cols-8 lg:[grid-template-columns:repeat(15,minmax(0,1fr))] !space-y-2 md:!space-y-6">
-          <AnimatePresence>
-            {changedFields.includes('skills') && (
-              <motion.div
-                key="banner"
-                initial={{ opacity: 0, y: -20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -20 }}
-                transition={{ duration: 0.4, ease: "easeOut" }}
-                className="absolute inset-0 flex items-center justify-center bg-orange-500/80 backdrop-blur-xl text-[#ff6d05] font-medium text-lg md:text-xl rounded-lg z-10"
-              >
-                <span className="">
-                  This section has been updated
-                </span>
-              </motion.div>
-            )}
-          </AnimatePresence>
+        <ItemLayout
+          ref={skillsRef}
+          className="col-span-full grid grid-cols-4 sm:grid-cols-8 lg:[grid-template-columns:repeat(15,minmax(0,1fr))] !space-y-2 md:!space-y-6 relative overflow-hidden"
+        >
+          <UpdateBanner
+            message={changedFields.includes('skills') ? "This section has been updated" : null}
+            visible={isSkillsInView}
+            srPrefix="Skills update: "
+          />
           {icons.map((icon) => (
             <div
               key={icon}
@@ -523,6 +765,17 @@ const AboutDetails = () => {
           </Link>
         </ItemLayout> */}
       </div>
+
+      {/* Mounted at the section root (outside the grid) so its
+          fixed-position backdrop covers the full viewport regardless
+          of the years card's position in the layout. Modal manages its
+          own AnimatePresence + body scroll lock + focus restoration. */}
+      <ExperienceBreakdownModal
+        open={isExperienceModalOpen}
+        onClose={() => setIsExperienceModalOpen(false)}
+        data={experienceData}
+        triggerRef={experienceTriggerRef}
+      />
     </section>
   );
 };

--- a/src/hooks/useExperienceSummary.js
+++ b/src/hooks/useExperienceSummary.js
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Polling interval mirrors the about page's /api/github-stats cadence.
+// The endpoint is server-cached (`unstable_cache`, 10 min TTL), so the
+// poll is cheap in steady state: most hits return from cache. Picks up
+// resume edits + GitHub repo create/rename/delete events within ~one
+// interval, which is the "live update" the experience modal needs.
+const POLL_INTERVAL_MS = 10 * 60 * 1000;
+
+// Per-username storage key so multiple identities on the same machine
+// don't clobber each other's last-seen payload. The current allowlist
+// pins us to one username, but the keying scheme stays future-proof.
+const storageKey = (username) => `experience-summary:last-payload:${username}`;
+
+// Stable identifier for a role across diff cycles — company + title +
+// start covers rename detection (title change with same start fires as
+// a "new role" record) while still avoiding false positives from
+// transient updatedAt-style fields not present on this payload.
+const roleKey = (r) => `${r?.company ?? ""}|${r?.role ?? ""}|${r?.start ?? ""}`;
+
+// Match the API's display formatter so the banner reads "5+ years"
+// rather than ambiguous raw numbers. Falls back to "0+ months" on
+// missing input.
+function formatTotalDisplay(total) {
+  const m = total?.months ?? 0;
+  if (m >= 12) {
+    const y = Math.floor(m / 12);
+    return `${y}+ ${y === 1 ? "year" : "years"}`;
+  }
+  return `${m}+ ${m === 1 ? "month" : "months"}`;
+}
+
+// Build the human-readable change message from a (prev, next) pair.
+// Returns null when nothing meaningful changed (banner stays hidden).
+// Messages are prioritised: the most specific / user-impacting change
+// wins, so we don't surface "1 new repository" when the actual story
+// is "new employment role".
+function buildChangeMessage(prev, next) {
+  if (!prev || !next) return null;
+
+  // 1. New employment role — highest priority because role additions
+  //    are rare and the most "headline" change for a portfolio.
+  const prevRoleKeys = new Set((prev.employment?.roles ?? []).map(roleKey));
+  const newRoles = (next.employment?.roles ?? []).filter(
+    (r) => !prevRoleKeys.has(roleKey(r)),
+  );
+  if (newRoles.length > 0) {
+    return `New role detected from resume: ${newRoles[0].company}`;
+  }
+
+  // 2. Total experience tipped over to a new "X+" bucket. Only fire
+  //    on an upward move per spec — counting *down* is a parser
+  //    regression and shouldn't be celebrated.
+  const prevDisplay = formatTotalDisplay(prev.total);
+  const nextDisplay = formatTotalDisplay(next.total);
+  if (
+    prevDisplay !== nextDisplay &&
+    (next.total?.months ?? 0) > (prev.total?.months ?? 0)
+  ) {
+    return `Years of experience updated: ${prevDisplay} → ${nextDisplay}`;
+  }
+
+  // 3. Employment months ticked without crossing a display bucket
+  //    boundary. Captures the in-between cases the bucket check
+  //    above misses (e.g. 14 → 16 months still reads as "1+ year").
+  const prevEmpMonths = prev.employment?.months ?? 0;
+  const nextEmpMonths = next.employment?.months ?? 0;
+  if (nextEmpMonths > prevEmpMonths) {
+    const delta = nextEmpMonths - prevEmpMonths;
+    return `Employment experience updated: +${delta} month${delta === 1 ? "" : "s"}`;
+  }
+
+  // 4. New repositories detected on GitHub. Surfaces creates without
+  //    being overly chatty about renames or deletes (handled below).
+  const prevRepoNames = new Set(
+    (prev.personalProjects?.repos ?? []).map((r) => r.name),
+  );
+  const newRepos = (next.personalProjects?.repos ?? []).filter(
+    (r) => !prevRepoNames.has(r.name),
+  );
+  if (newRepos.length === 1) {
+    return `New repository detected: ${newRepos[0].name}`;
+  }
+  if (newRepos.length > 1) {
+    return `${newRepos.length} new repositories detected on GitHub`;
+  }
+
+  // 5. Source-date drift: the earliest-repo date changed (probably
+  //    because the previously-earliest repo was deleted or renamed).
+  if (
+    prev.personalProjects?.firstRepoDate !==
+    next.personalProjects?.firstRepoDate
+  ) {
+    return "Personal projects timeline updated";
+  }
+
+  return null;
+}
+
+// Strip volatile fields before serialising — `generatedAt` and the
+// `changeFingerprint` itself change every fetch and would defeat the
+// "did anything *meaningful* change" check.
+function pickContent(payload) {
+  if (!payload) return null;
+  const { generatedAt, changeFingerprint, ...rest } = payload;
+  return rest;
+}
+
+function readStoredPayload(username) {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(storageKey(username));
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    // Corrupt entry or storage access blocked — treat as no prior
+    // baseline so the banner stays silent on the next compare.
+    return null;
+  }
+}
+
+function writeStoredPayload(username, content) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey(username), JSON.stringify(content));
+  } catch {
+    // QuotaExceededError, private-mode blocks, etc. The hook still
+    // returns the live data; we just lose the next-visit diff.
+  }
+}
+
+/**
+ * Client hook for `/api/experience-summary`.
+ *
+ * Fetches on mount, then re-fetches every `POLL_INTERVAL_MS` so a
+ * long-open about page picks up GitHub repo changes (rename/create/
+ * delete) and resume edits without a manual refresh.
+ *
+ * Diffs each response against the last payload stored in
+ * `localStorage` so the banner can announce "Years of experience
+ * updated: 4+ → 5+" only when the value actually moves between visits
+ * (or polls). First-ever load has no baseline → no message; subsequent
+ * loads / polls compare content fields (excluding generatedAt /
+ * fingerprint) and surface the highest-priority change. After the
+ * compare runs, the new payload becomes the stored baseline.
+ *
+ * @param {string} username
+ * @returns {{
+ *   data: object|null,
+ *   isLoading: boolean,
+ *   error: Error|null,
+ *   changeMessage: string|null
+ * }}
+ */
+export function useExperienceSummary(username) {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  // `null` = no banner-worthy change to display (either first load or
+  // current === last stored). Set to a human-readable sentence when a
+  // meaningful diff is detected. Consumed by ExperienceUpdateBanner,
+  // which manages its own one-shot-per-message display logic.
+  const [changeMessage, setChangeMessage] = useState(null);
+
+  useEffect(() => {
+    if (!username) {
+      setIsLoading(false);
+      return;
+    }
+
+    // Cancellation flag so a late response can't `setState` after the
+    // component unmounts (or after a StrictMode double-mount). We
+    // *don't* use a module/ref guard to dedupe across mounts — that
+    // would skip the legitimate second mount entirely and leave the
+    // component stranded with `data: null` (the first mount's response
+    // was cancelled, the second never refetched). Letting both mounts
+    // fetch is harmless: the browser/HTTP cache absorbs the duplicate
+    // in dev, and StrictMode isn't active in production.
+    let cancelled = false;
+
+    const fetchOnce = async () => {
+      try {
+        const res = await fetch(
+          `/api/experience-summary?username=${encodeURIComponent(username)}`,
+        );
+        if (!res.ok) {
+          throw new Error(
+            `experience-summary HTTP ${res.status} ${res.statusText}`,
+          );
+        }
+        const payload = await res.json();
+        if (cancelled) return;
+
+        // Diff against stored baseline before updating storage —
+        // otherwise the comparison would always see itself and never
+        // produce a message. `pickContent` strips volatile fields so
+        // identical content doesn't trip on `generatedAt` drift.
+        const nextContent = pickContent(payload);
+        const prevContent = readStoredPayload(username);
+        const message = buildChangeMessage(prevContent, nextContent);
+        if (message) {
+          setChangeMessage(message);
+        }
+        writeStoredPayload(username, nextContent);
+
+        setData(payload);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        // Log but don't throw — the about page should still render with
+        // its other cards even when this endpoint is degraded.
+        console.warn("useExperienceSummary fetch failed:", err);
+        setError(err);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    fetchOnce();
+    const intervalId = setInterval(fetchOnce, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [username]);
+
+  return { data, isLoading, error, changeMessage };
+}

--- a/src/hooks/useExperienceSummary.js
+++ b/src/hooks/useExperienceSummary.js
@@ -165,6 +165,13 @@ export function useExperienceSummary(username) {
   const [changeMessage, setChangeMessage] = useState(null);
 
   useEffect(() => {
+    // Clear any message from a previous username on every effect
+    // re-run, so a consumer can't briefly render a sentence that
+    // belonged to the prior username (or to no username at all when
+    // the caller has unset it). Per-poll clearing inside `fetchOnce`
+    // handles the no-diff case; this clears the cross-username case.
+    setChangeMessage(null);
+
     if (!username) {
       setIsLoading(false);
       return;
@@ -200,9 +207,13 @@ export function useExperienceSummary(username) {
         const nextContent = pickContent(payload);
         const prevContent = readStoredPayload(username);
         const message = buildChangeMessage(prevContent, nextContent);
-        if (message) {
-          setChangeMessage(message);
-        }
+        // Always set the state to the current comparison result —
+        // including `null` when there's no diff. The previous "only set
+        // when truthy" path left a stale sentence on screen across
+        // subsequent no-diff polls. ExperienceUpdateBanner dedupes its
+        // one-shot display via sessionStorage, so writing `null` here
+        // just means "no new banner-worthy change this poll".
+        setChangeMessage(message);
         writeStoredPayload(username, nextContent);
 
         setData(payload);

--- a/src/hooks/useViewportCountTrigger.js
+++ b/src/hooks/useViewportCountTrigger.js
@@ -1,0 +1,107 @@
+"use client";
+
+import { useInView } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Viewport-driven "play this animation once per entry cycle" trigger.
+ *
+ * Wraps framer-motion's `useInView` and returns a monotonically-
+ * increasing `playToken` that increments exactly once per *true* entry
+ * — not on every IntersectionObserver flicker. Consumers depend on
+ * `playToken` in their effect deps instead of raw `isInView`, which
+ * solves the issue #16/17 bug class where rapid in/out scroll
+ * oscillations restart a count-up several times in a row, or where the
+ * counter resets to 0 when the user is still actively viewing the card
+ * but just nudged it past the threshold.
+ *
+ * Semantics:
+ *   - First entry after mount → playToken: 0 → 1, consumer animates.
+ *   - Continuous visibility (incl. brief flickers absorbed by
+ *     `leaveDelayMs`) → playToken stable, consumer effect does not re-
+ *     fire purely because of the flicker.
+ *   - Sustained exit (≥ `leaveDelayMs` outside the viewport) re-arms
+ *     the trigger; the next entry increments playToken again.
+ *
+ * Returns `{ isInView, playToken }`:
+ *   - `isInView` mirrors the underlying observer (use it for things
+ *     that should reflect raw visibility, e.g. lazy mounting or
+ *     pausing autoplay).
+ *   - `playToken` is the latched, hysteresis-debounced trigger value.
+ *     A consumer that depends on `[playToken, target]` will animate
+ *     when either a real entry happens or the data changes.
+ *
+ * @param {React.RefObject<HTMLElement>} ref - element to observe
+ * @param {object} [options]
+ * @param {number} [options.amount=0.3]      - intersection ratio (passed to useInView)
+ * @param {string} [options.margin="0px"]    - rootMargin (passed to useInView)
+ * @param {number} [options.leaveDelayMs=300]- hysteresis on exit; element must
+ *                                             stay out at least this long before
+ *                                             the next entry counts as a new cycle
+ */
+export function useViewportCountTrigger(ref, options = {}) {
+  const {
+    amount = 0.3,
+    margin = "0px",
+    leaveDelayMs = 300,
+  } = options;
+
+  const isInView = useInView(ref, { once: false, amount, margin });
+
+  // `playToken` is the only piece of state — every other "is it time to
+  // trigger?" piece of book-keeping lives in refs so it doesn't itself
+  // cause re-renders. The state change happens exactly once per real
+  // entry cycle, which is also the only time consumers want to react.
+  const [playToken, setPlayToken] = useState(0);
+
+  // `armedRef` flips false the moment we fire a trigger and only
+  // returns to true after the leave-delay timer elapses with the
+  // element continuously out of view. This is the "consume once per
+  // entry" latch.
+  const armedRef = useRef(true);
+
+  // Holds the pending re-arm timeout so a quick flicker back into view
+  // can cancel it before it fires. Survives across effect re-runs
+  // because effect cleanup doesn't clear it — only an actual re-entry
+  // (the effect body) does. Cleared on unmount via the second effect.
+  const leaveTimerRef = useRef(null);
+
+  useEffect(() => {
+    if (isInView) {
+      // True entry (or recovery from a flicker). Cancel any pending
+      // re-arm because we're back before the debounce expired —
+      // continuous visibility shouldn't restart the cycle.
+      if (leaveTimerRef.current) {
+        clearTimeout(leaveTimerRef.current);
+        leaveTimerRef.current = null;
+      }
+      if (armedRef.current) {
+        armedRef.current = false;
+        setPlayToken((t) => t + 1);
+      }
+    } else if (!leaveTimerRef.current) {
+      // Sustained-exit candidate. Don't immediately re-arm — wait the
+      // debounce so brief intersection-observer wobble (especially on
+      // mobile momentum scroll past element edges) is absorbed.
+      leaveTimerRef.current = setTimeout(() => {
+        armedRef.current = true;
+        leaveTimerRef.current = null;
+      }, leaveDelayMs);
+    }
+  }, [isInView, leaveDelayMs]);
+
+  // Cleanup only on unmount. Note this is intentionally a separate
+  // effect with an empty dep array: the cleanup in the trigger effect
+  // above would otherwise fire on every isInView change, killing the
+  // hysteresis timer before it can do its job.
+  useEffect(() => {
+    return () => {
+      if (leaveTimerRef.current) {
+        clearTimeout(leaveTimerRef.current);
+        leaveTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  return { isInView, playToken };
+}

--- a/src/utils/experience/dateMath.js
+++ b/src/utils/experience/dateMath.js
@@ -1,0 +1,103 @@
+// Shared month / year duration helpers for the experience summary. All
+// month math is in *whole calendar months elapsed* (exclusive) — Feb 2026
+// → May 2026 = 3, not 4 — so the same formula works for closed ranges
+// and for "Current" ranges measured against today. Display formatting
+// follows the "X+ years/months" convention from the issue #17 spec.
+
+// Lowercase month-name → 0-indexed month for `new Date(year, month, 1)`.
+// Both 3-letter and full names so the parser tolerates either form on
+// the resume (the current CV uses 3-letter, but spec allows long form).
+const MONTH_INDEX = {
+  jan: 0, january: 0,
+  feb: 1, february: 1,
+  mar: 2, march: 2,
+  apr: 3, april: 3,
+  may: 4,
+  jun: 5, june: 5,
+  jul: 6, july: 6,
+  aug: 7, august: 7,
+  sep: 8, sept: 8, september: 8,
+  oct: 9, october: 9,
+  nov: 10, november: 10,
+  dec: 11, december: 11,
+};
+
+// Whole calendar months between two Dates (exclusive end). Negative if
+// `end` precedes `start`; clamped to 0 by the caller when that's
+// nonsensical (e.g. employment span). Day-of-month is intentionally
+// ignored so "Feb 2026 → Apr 5 2026" still reads as 2 months.
+// UTC accessors used throughout so the result is independent of the
+// server's local timezone — Vercel functions run in UTC, but local
+// `npm run dev` in any non-UTC zone (BST, PST, etc.) would otherwise
+// drift the month boundary across midnight and produce off-by-one
+// months for first-of-month inputs.
+export function monthsBetween(start, end) {
+  if (!(start instanceof Date) || !(end instanceof Date)) return 0;
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) return 0;
+  return (
+    (end.getUTCFullYear() - start.getUTCFullYear()) * 12 +
+    (end.getUTCMonth() - start.getUTCMonth())
+  );
+}
+
+// Human-readable duration matching the spec: "5+ years", "2+ months",
+// "1+ year" (singular for exactly-1). The "+" suffix signals "at least"
+// since we floor partial years and don't double-count partial months.
+// `formatDuration(0)` returns "0+ months" — caller can decide whether to
+// hide that, but the helper itself returns a valid string for every
+// non-negative input.
+export function formatDuration(months) {
+  const m = Math.max(0, Math.floor(Number(months) || 0));
+  if (m >= 12) {
+    const years = Math.floor(m / 12);
+    return `${years}+ ${years === 1 ? "year" : "years"}`;
+  }
+  return `${m}+ ${m === 1 ? "month" : "months"}`;
+}
+
+// Parse a single date token from the resume PDF. Tolerates the formats
+// the spec enumerates plus the variants actually present in the current
+// CV: "Feb 2026", "Feb/2026", "February 2026", "2024", and the literal
+// "Current" / "Present" sentinels (both treated as today). Returns a
+// Date pinned to the first of the month, or null on anything it can't
+// recognize — callers should treat null as "skip this role" rather than
+// guessing, so an unexpected format produces no role rather than a wrong
+// one.
+export function parseResumeDateToken(token) {
+  if (typeof token !== "string") return null;
+  const t = token.trim().toLowerCase();
+  if (t.length === 0) return null;
+
+  // Open-ended endpoint. Spec lists "Current"; resumes in the wild also
+  // commonly use "Present". Treating both as "now" since the next
+  // monthsBetween call quantizes to month granularity anyway.
+  if (t === "current" || t === "present") return new Date();
+
+  // All constructed dates pin to the 1st of the month at 00:00 UTC so
+  // downstream `.toISOString().slice(0, 10)` formatting can't drift
+  // across a day boundary based on the server's timezone. `Date.UTC`
+  // is the only constructor form that produces a deterministic instant
+  // for a given (year, month, day) tuple regardless of process locale.
+
+  // "<month> <year>" with space, slash, or hyphen separator. The hyphen
+  // form is unusual but cheap to accept; the slash form is in the spec.
+  const monthYear = t.match(/^([a-z]+)[\s/-](\d{4})$/);
+  if (monthYear) {
+    const month = MONTH_INDEX[monthYear[1]];
+    const year = parseInt(monthYear[2], 10);
+    if (month !== undefined && !Number.isNaN(year)) {
+      return new Date(Date.UTC(year, month, 1));
+    }
+  }
+
+  // Bare year ("2024") — falls back to January so duration math still
+  // works. Loses the start-of-year precision but no resume omits month
+  // for ongoing roles in practice; this is for closed-range fallbacks.
+  const yearOnly = t.match(/^(\d{4})$/);
+  if (yearOnly) {
+    const year = parseInt(yearOnly[1], 10);
+    if (!Number.isNaN(year)) return new Date(Date.UTC(year, 0, 1));
+  }
+
+  return null;
+}

--- a/src/utils/experience/pdfExperienceParser.js
+++ b/src/utils/experience/pdfExperienceParser.js
@@ -1,5 +1,3 @@
-import { PDFParse } from "pdf-parse";
-
 import { isSoftwareRole } from "./roleKeywords";
 import {
   formatDuration,
@@ -34,9 +32,13 @@ const ROLE_LINE_REGEX =
   /^([^•\n]+?)\s+[–-]\s+([^,\n]+),\s+[^()\n]*?\(([^)]+)\)\s*$/gm;
 
 // Resume date ranges use either an en-dash (U+2013) or a plain hyphen,
-// often with surrounding whitespace. Splitting on the union handles both
-// without requiring a normalisation pass on the upstream text.
-const DATE_RANGE_SEPARATOR = /\s*[–-]\s*/;
+// flanked by whitespace ("Feb 2024 - Present", "Feb 2024 – Present").
+// Mandatory whitespace on both sides is what disambiguates the *range*
+// separator from a hyphen that lives *inside* a token — the spec
+// (see `parseResumeDateToken`) accepts "Feb-2024" as a month-year, so
+// the previous greedy `\s*` form would shred "Feb-2024 - Present" into
+// three parts and silently drop the role.
+const DATE_RANGE_SEPARATOR = /\s+[–-]\s+/;
 
 // Pull the main Experience block out of the full document text. Returns
 // an empty string when the header is missing so the caller can degrade
@@ -81,17 +83,36 @@ function parseDateRange(rangeText) {
 // with a Buffer fixture. Returns `{ roles, rawText }`; `rawText` is
 // included so callers can log a snippet on parse failures.
 export async function parseExperienceFromPdf(pdfBuffer) {
+  // Dynamic import so `pdfjs-dist` (a transitive dep of `pdf-parse`)
+  // isn't evaluated at module load. Its top-level code references
+  // browser-only globals (DOMMatrix, ImageData, Path2D), which crash
+  // Next.js's build-time "Collecting page data" pass — that pass
+  // imports route modules in plain Node, before the runtime hint
+  // (`export const runtime = "nodejs"`) gets a chance to matter.
+  // Deferring the import keeps the route bundleable.
+  const { PDFParse } = await import("pdf-parse");
   // PDFParse expects a Uint8Array; Node's Buffer is one but the type
   // check inside pdf-parse is stricter than necessary, so the
   // conversion is defensive.
   const parser = new PDFParse({ data: new Uint8Array(pdfBuffer) });
-  const result = await parser.getText();
+  // pdf-parse v2's `PDFParse` holds onto the worker-side pdfjs document
+  // until `destroy()` is called. In a long-lived serverless worker
+  // (Vercel keeps Node instances warm across invocations) leaving these
+  // around accumulates memory across cache misses. The try/finally
+  // guarantees cleanup even if `getText` throws — important because the
+  // outer `Promise.allSettled` in the route will swallow a thrown
+  // failure but a leaked parser would still consume the worker's heap.
+  let result;
+  try {
+    result = await parser.getText();
+  } finally {
+    await parser.destroy();
+  }
   const text = result?.text ?? "";
 
   const block = extractExperienceBlock(text);
   if (!block) return { roles: [], rawText: text };
 
-  const now = new Date();
   const roles = [];
   // Reset lastIndex because the regex is module-scoped (global flag
   // makes it stateful across calls). Without this, a second invocation

--- a/src/utils/experience/pdfExperienceParser.js
+++ b/src/utils/experience/pdfExperienceParser.js
@@ -1,0 +1,130 @@
+import { PDFParse } from "pdf-parse";
+
+import { isSoftwareRole } from "./roleKeywords";
+import {
+  formatDuration,
+  monthsBetween,
+  parseResumeDateToken,
+} from "./dateMath";
+
+// Headings that signal the end of the main Experience block. "Additional
+// Experience" is intentionally listed so the parser stops *before* it —
+// per the issue #17 spec, only the primary Experience section feeds the
+// software-experience aggregate. The role-keyword filter is a second
+// gate so a non-software role accidentally inside the main section also
+// gets dropped.
+const SECTION_TERMINATORS = [
+  "Additional Experience",
+  "Interpersonal Skills",
+  "Languages",
+  "Education",
+  "Technical Skills",
+  "Projects",
+  "Personal Profile",
+  "Awards",
+];
+
+// Match every role line within the experience block. The shape we expect
+// (validated against the real CV): "<title> [–|-] <company>, <location>
+// (<startDate> [–|-] <endDate>)". The leading `[^•\n]` guard excludes
+// bullet sub-items; the en-dash / hyphen alternation covers both common
+// glyphs without normalising the source text first. Multiline + global
+// so a single `exec` loop reads every role in the block.
+const ROLE_LINE_REGEX =
+  /^([^•\n]+?)\s+[–-]\s+([^,\n]+),\s+[^()\n]*?\(([^)]+)\)\s*$/gm;
+
+// Resume date ranges use either an en-dash (U+2013) or a plain hyphen,
+// often with surrounding whitespace. Splitting on the union handles both
+// without requiring a normalisation pass on the upstream text.
+const DATE_RANGE_SEPARATOR = /\s*[–-]\s*/;
+
+// Pull the main Experience block out of the full document text. Returns
+// an empty string when the header is missing so the caller can degrade
+// gracefully rather than throw — a CV layout change shouldn't take down
+// the about page.
+function extractExperienceBlock(text) {
+  // Anchor on the *line* "Experience" so we don't false-match the word
+  // inside Personal Profile prose ("over two years' commercial
+  // experience"). The newline before the header is required.
+  const startMatch = text.match(/(?:^|\n)Experience\s*\n/);
+  if (!startMatch) return "";
+  const blockStart = startMatch.index + startMatch[0].length;
+
+  // Stop at whichever terminator appears first. Using a single combined
+  // regex with alternation lets us defer "which heading came first" to
+  // the regex engine instead of running N separate searches.
+  const terminatorPattern = new RegExp(
+    `\\n(?:${SECTION_TERMINATORS.map((s) =>
+      s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+    ).join("|")})\\b`,
+  );
+  const after = text.slice(blockStart);
+  const endMatch = after.match(terminatorPattern);
+  return endMatch ? after.slice(0, endMatch.index) : after;
+}
+
+// Parse a single "<start> [–|-] <end>" range into Date objects via
+// `parseResumeDateToken`. Returns null when either side fails to parse
+// so the caller can skip the role rather than emit a meaningless 0- or
+// NaN-month duration.
+function parseDateRange(rangeText) {
+  const parts = rangeText.split(DATE_RANGE_SEPARATOR);
+  if (parts.length !== 2) return null;
+  const start = parseResumeDateToken(parts[0]);
+  const end = parseResumeDateToken(parts[1]);
+  if (!start || !end) return null;
+  return { start, end, openEnded: /^(current|present)$/i.test(parts[1].trim()) };
+}
+
+// Extract structured roles from a PDF buffer. Pure function aside from
+// the pdf-parse call — no fs, no network, so it's trivially testable
+// with a Buffer fixture. Returns `{ roles, rawText }`; `rawText` is
+// included so callers can log a snippet on parse failures.
+export async function parseExperienceFromPdf(pdfBuffer) {
+  // PDFParse expects a Uint8Array; Node's Buffer is one but the type
+  // check inside pdf-parse is stricter than necessary, so the
+  // conversion is defensive.
+  const parser = new PDFParse({ data: new Uint8Array(pdfBuffer) });
+  const result = await parser.getText();
+  const text = result?.text ?? "";
+
+  const block = extractExperienceBlock(text);
+  if (!block) return { roles: [], rawText: text };
+
+  const now = new Date();
+  const roles = [];
+  // Reset lastIndex because the regex is module-scoped (global flag
+  // makes it stateful across calls). Without this, a second invocation
+  // would resume mid-text and skip the first role.
+  ROLE_LINE_REGEX.lastIndex = 0;
+  let match;
+  while ((match = ROLE_LINE_REGEX.exec(block)) !== null) {
+    const [, rawTitle, rawCompany, rawDateRange] = match;
+    const title = rawTitle.trim();
+    const company = rawCompany.trim();
+
+    // Section filter is implicit (we only look at the main Experience
+    // block); keyword filter is the second gate per the spec.
+    if (!isSoftwareRole(title)) continue;
+
+    const range = parseDateRange(rawDateRange);
+    if (!range) continue;
+
+    // Months are clamped non-negative: an inverted range on the CV
+    // (typo, future-dated role) shouldn't yield a negative aggregate.
+    // For open-ended roles, end is "now" — already correct via
+    // parseResumeDateToken's Current/Present handling.
+    const months = Math.max(0, monthsBetween(range.start, range.end));
+
+    roles.push({
+      company,
+      role: title,
+      start: range.start.toISOString().slice(0, 10),
+      end: range.openEnded ? null : range.end.toISOString().slice(0, 10),
+      months,
+      display: `${formatDuration(months)} with ${company} as a ${title}`,
+    });
+  }
+
+  return { roles, rawText: text };
+}

--- a/src/utils/experience/roleKeywords.js
+++ b/src/utils/experience/roleKeywords.js
@@ -1,0 +1,36 @@
+// Centralized allowlist for filtering employment roles down to those that
+// count as "software-engineering experience." Used by the resume parser to
+// drop unrelated roles (e.g. "Security Officer", retail shifts) before
+// aggregating months. Substring match is case-insensitive and runs against
+// the role title only — the company name and bullet text are ignored.
+//
+// Keep entries lowercase. Order doesn't matter; `isSoftwareRole` exits on
+// the first hit. Add new keywords here rather than in callers so the
+// filter stays consistent across the API route, the parser, and any
+// future debug tooling.
+export const SOFTWARE_ROLE_KEYWORDS = Object.freeze([
+  "software",
+  "engineer",
+  "developer",
+  "full stack",
+  "fullstack",
+  "frontend",
+  "backend",
+  "devops",
+  "platform",
+  "sre",
+  "site reliability",
+  "cloud",
+  "data engineer",
+  "ml",
+  "machine learning",
+]);
+
+export function isSoftwareRole(title) {
+  if (typeof title !== "string" || title.length === 0) return false;
+  const t = title.toLowerCase();
+  for (const kw of SOFTWARE_ROLE_KEYWORDS) {
+    if (t.includes(kw)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
This pull request introduces a new `/api/experience-summary` endpoint that combines GitHub repository data with parsed resume PDF information to provide a comprehensive experience summary, with robust caching and cache revalidation. It also includes visual and usability improvements to the about page, such as new gold/cyan text styles, a fire-gradient text effect, and a modal-aware home button. Additionally, the update refines the cache warming and invalidation logic for the new endpoint and enhances component flexibility and layout consistency.

**API and Backend Enhancements:**

* Added a new `experience-summary` API route (`src/app/api/experience-summary/route.js`) that aggregates GitHub owned repositories and employment history parsed from a PDF, with robust error handling, cache tagging, and a stable change fingerprint for UI updates.
* Updated Next.js config to mark `pdf-parse` as an external server component dependency, ensuring correct runtime bundling.
* Added `pdf-parse` as a dependency in `package.json`.

**Cache Management and Warming:**

* Enhanced the `/api/repo-refresh` endpoint to invalidate and warm the new `experience-summary` cache tag alongside existing tags, ensuring all caches are kept fresh both on schedule and after user-triggered refreshes. [[1]](diffhunk://#diff-abf0e4284cac5880968e36b77976c79351d9baa1a28cd650c9972a25267ffb4fL24-R32) [[2]](diffhunk://#diff-abf0e4284cac5880968e36b77976c79351d9baa1a28cd650c9972a25267ffb4fR76-R80) [[3]](diffhunk://#diff-abf0e4284cac5880968e36b77976c79351d9baa1a28cd650c9972a25267ffb4fR147-R180)

**UI and Styling Improvements:**

* Added new gold and cyan text styles, a fire-amber gradient text effect, and a visually richer `.custom-bg-abt` background for about page cards in `globals.css`. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L30-R38) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R54-R85) [[3]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R137-R160)
* Added CSS to hide the home button when a modal is open, improving modal focus and preventing UI overlap.

**Component and Layout Updates:**

* Introduced `ExperienceUpdateBanner`, a client-side component that displays a one-time, auto-dismissing banner when the experience summary changes, matching the look and feel of other update banners.
* Refactored `ItemsLayout` to use `forwardRef` and spread props, improving flexibility for future consumers and fixing layout issues when multiple children are present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive Experience breakdown modal with animated charts, counters, and accessible keyboard/focus behavior
  * Live experience summary endpoint with client polling that surfaces focused change notifications

* **Style**
  * Enhanced card/modal visuals with layered gradients, new color utilities, and improved update animations

* **Refactor**
  * Count-up and reveal animations now trigger reliably on viewport entry and replay correctly

* **Chores**
  * PDF resume parsing support added and Node engine requirement updated for installs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MA1002643/theabdullahfolio/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->