### PR TITLE
feat: enhance experience summary handling and improve accessibility in components

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,20 @@ const nextConfig = {
   // `Object.defineProperty called on non-object` at import time.
   experimental: {
     serverComponentsExternalPackages: ["pdf-parse"],
+    // Output File Tracing — explicitly bundle the resume PDF with the
+    // experience-summary serverless function. By default, Next only
+    // ships files referenced from imports; `public/` assets get
+    // deployed to the static layer but are NOT copied into the
+    // function's filesystem. Locally `process.cwd()` is the repo root
+    // so `fs.readFile` finds the PDF; on Vercel it points to the
+    // function bundle, the PDF isn't there, `parseExperienceFromPdf`
+    // rejects, and the modal renders an empty Employment side. Listing
+    // the file here pulls it into the function bundle so the runtime
+    // path resolves identically in prod. In Next 14.x this option
+    // lives under `experimental`; it became top-level in Next 15+.
+    outputFileTracingIncludes: {
+      "/api/experience-summary": ["./public/Muhammad_Abdullah_CV.pdf"],
+    },
   },
   async headers() {
     return [

--- a/src/components/about/ExperienceBreakdownModal.jsx
+++ b/src/components/about/ExperienceBreakdownModal.jsx
@@ -522,15 +522,35 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
             // rounded corners clip the scrollbar that lives on the
             // inner `scrollRef` div — keeps the scrollbar inside the
             // gold border rather than sitting on top of it.
+            //
+            // Sizing uses `dvh` via inline style with a `vh` Tailwind
+            // fallback. On iOS Safari, `100vh` includes the height of
+            // the URL bar even when it's collapsed, which makes the
+            // modal taller than the truly visible viewport — scrolling
+            // inside the modal then shrinks the URL bar and the panel
+            // appears to "jump" relative to the visible area. `dvh`
+            // tracks the dynamic visible viewport, so the panel stays
+            // pinned to the actual on-screen edges no matter what iOS
+            // does with its chrome. Browsers without `dvh` support
+            // silently ignore the inline style and fall back to vh.
             className="custom-bg-abt rounded-2xl w-full max-w-2xl max-h-[88vh] overflow-hidden text-white relative"
             style={{
+              maxHeight: "88dvh",
               filter: "drop-shadow(0 24px 60px rgba(0, 0, 0, 0.6))",
             }}
             onClick={(e) => e.stopPropagation()}
           >
             <div
               ref={scrollRef}
-              className="max-h-[88vh] overflow-y-auto p-6 sm:p-8"
+              // `overscroll-contain` stops a momentum scroll that
+              // bottoms out (or tops out) in the repo list from
+              // bubbling up to the modal panel or the locked body —
+              // on iOS that escaped scroll was what made the whole
+              // panel feel like it was sliding around. Same `dvh`
+              // sizing trick as the panel above so the scroll region
+              // matches the visible viewport on iOS.
+              className="max-h-[88vh] overflow-y-auto overscroll-contain p-6 sm:p-8"
+              style={{ maxHeight: "88dvh" }}
             >
             <header className="flex items-start justify-between gap-4 mb-6">
               <div>
@@ -731,7 +751,7 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
                   ))}
                 </ul>
               ) : (
-                <p className="text-sm text-[#d4af7a]">
+                <p className="text-sm text-fire-amber">
                   No software-engineering roles detected yet.
                 </p>
               )}

--- a/src/components/about/UpdateBanner.jsx
+++ b/src/components/about/UpdateBanner.jsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Fragment } from "react";
+
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 // Visual variants. Each variant ships every token needed by the full
@@ -177,7 +179,13 @@ function AnimatedMessage({ message, prefersReducedMotion }) {
         // every space in an inline-block, which let the parent's
         // (now removed) `whitespace-nowrap` keep the whole message on
         // one line and overflow long sentences into `overflow-hidden`.
-        if (c === " ") return " ";
+        // A keyed Fragment is used (rather than a bare " ") so every
+        // entry in the mapped array carries a stable key — React tolerates
+        // unkeyed text nodes in lists today but the keyed form is more
+        // defensive against future versions and clearer at a glance.
+        if (c === " ") {
+          return <Fragment key={i}> </Fragment>;
+        }
         return (
           <motion.span
             key={i}

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -610,17 +610,28 @@ const AboutDetails = () => {
 
         <ItemLayout
           ref={experienceTriggerRef}
-          role="button"
-          tabIndex={experienceData ? 0 : -1}
-          aria-haspopup="dialog"
-          aria-expanded={isExperienceModalOpen}
-          aria-label={
-            experienceData
-              ? `${experienceCounterValue}+ ${experienceCounterUnit} of experience. Activate to open category breakdown.`
-              : "Loading experience summary"
-          }
-          onClick={openExperienceModal}
-          onKeyDown={handleExperienceTriggerKeyDown}
+          // Button semantics are only attached once `experienceData`
+          // resolves. While loading, the card is a plain informational
+          // region with `aria-busy` — exposing role="button" + click
+          // handlers on a control that no-ops would mislead AT users in
+          // virtual-cursor mode (they'd hear "button", activate it, and
+          // get nothing). The trigger contract (role, tabIndex, ARIA
+          // popup state, click/keydown handlers) all attach atomically
+          // the moment the data lands.
+          {...(experienceData
+            ? {
+                role: "button",
+                tabIndex: 0,
+                "aria-haspopup": "dialog",
+                "aria-expanded": isExperienceModalOpen,
+                "aria-label": `${experienceCounterValue}+ ${experienceCounterUnit} of experience. Activate to open category breakdown.`,
+                onClick: openExperienceModal,
+                onKeyDown: handleExperienceTriggerKeyDown,
+              }
+            : {
+                "aria-busy": true,
+                "aria-label": "Loading experience summary",
+              })}
           className={`group relative col-span-full xs:col-span-6 lg:col-span-4 text-accent flex-col !items-stretch !justify-center ${
             experienceData ? "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/50" : "cursor-default"
           }`}

--- a/src/hooks/useExperienceSummary.js
+++ b/src/hooks/useExperienceSummary.js
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 
+import { formatDuration } from "@/utils/experience/dateMath";
+
 // Polling interval mirrors the about page's /api/github-stats cadence.
 // The endpoint is server-cached (`unstable_cache`, 10 min TTL), so the
 // poll is cheap in steady state: most hits return from cache. Picks up
@@ -19,18 +21,6 @@ const storageKey = (username) => `experience-summary:last-payload:${username}`;
 // a "new role" record) while still avoiding false positives from
 // transient updatedAt-style fields not present on this payload.
 const roleKey = (r) => `${r?.company ?? ""}|${r?.role ?? ""}|${r?.start ?? ""}`;
-
-// Match the API's display formatter so the banner reads "5+ years"
-// rather than ambiguous raw numbers. Falls back to "0+ months" on
-// missing input.
-function formatTotalDisplay(total) {
-  const m = total?.months ?? 0;
-  if (m >= 12) {
-    const y = Math.floor(m / 12);
-    return `${y}+ ${y === 1 ? "year" : "years"}`;
-  }
-  return `${m}+ ${m === 1 ? "month" : "months"}`;
-}
 
 // Build the human-readable change message from a (prev, next) pair.
 // Returns null when nothing meaningful changed (banner stays hidden).
@@ -52,9 +42,12 @@ function buildChangeMessage(prev, next) {
 
   // 2. Total experience tipped over to a new "X+" bucket. Only fire
   //    on an upward move per spec — counting *down* is a parser
-  //    regression and shouldn't be celebrated.
-  const prevDisplay = formatTotalDisplay(prev.total);
-  const nextDisplay = formatTotalDisplay(next.total);
+  //    regression and shouldn't be celebrated. Display strings come
+  //    from the same `formatDuration` helper the server uses for its
+  //    `total.display` field, so the banner text can't drift from the
+  //    payload's own formatting over time.
+  const prevDisplay = formatDuration(prev.total?.months ?? 0);
+  const nextDisplay = formatDuration(next.total?.months ?? 0);
   if (
     prevDisplay !== nextDisplay &&
     (next.total?.months ?? 0) > (prev.total?.months ?? 0)

--- a/src/utils/experience/roleKeywords.js
+++ b/src/utils/experience/roleKeywords.js
@@ -1,13 +1,20 @@
 // Centralized allowlist for filtering employment roles down to those that
 // count as "software-engineering experience." Used by the resume parser to
 // drop unrelated roles (e.g. "Security Officer", retail shifts) before
-// aggregating months. Substring match is case-insensitive and runs against
-// the role title only — the company name and bullet text are ignored.
+// aggregating months.
 //
-// Keep entries lowercase. Order doesn't matter; `isSoftwareRole` exits on
-// the first hit. Add new keywords here rather than in callers so the
-// filter stays consistent across the API route, the parser, and any
-// future debug tooling.
+// Matching is case-insensitive and *word-boundary aware on the leading
+// edge* — a plain substring match would let short abbreviations like
+// "ml" and "sre" false-positive against unrelated tokens ("HTML",
+// "XML", "presale"). Boundary-on-the-left + free-form right side keeps
+// the inflected forms working (e.g. the keyword "engineer" still
+// matches "engineering" and "engineers", and "developer" matches
+// "developers"), while rejecting mid-word collisions.
+//
+// Keep entries lowercase. Order doesn't matter; `isSoftwareRole` exits
+// on the first hit. Add new keywords here rather than in callers so
+// the filter stays consistent across the API route, the parser, and
+// any future debug tooling.
 export const SOFTWARE_ROLE_KEYWORDS = Object.freeze([
   "software",
   "engineer",
@@ -26,11 +33,26 @@ export const SOFTWARE_ROLE_KEYWORDS = Object.freeze([
   "machine learning",
 ]);
 
+// Escape regex metacharacters so a keyword containing one (e.g. a
+// future ".net" or "C++") doesn't blow up the compiled regex. None of
+// the current entries trigger any escape, but the future-proofing is
+// nearly free.
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Precompile one regex per keyword. `\b` on the left only; the right
+// side is unbounded so "engineer" matches "engineer" / "engineering" /
+// "engineers" without each variant being added to the list. Building
+// regexes at module load keeps `isSoftwareRole` allocation-free.
+const KEYWORD_REGEXES = SOFTWARE_ROLE_KEYWORDS.map(
+  (kw) => new RegExp(`\\b${escapeRegex(kw)}`, "i"),
+);
+
 export function isSoftwareRole(title) {
   if (typeof title !== "string" || title.length === 0) return false;
-  const t = title.toLowerCase();
-  for (const kw of SOFTWARE_ROLE_KEYWORDS) {
-    if (t.includes(kw)) return true;
+  for (const re of KEYWORD_REGEXES) {
+    if (re.test(title)) return true;
   }
   return false;
 }

--- a/src/utils/experience/roleKeywords.js
+++ b/src/utils/experience/roleKeywords.js
@@ -41,12 +41,22 @@ function escapeRegex(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-// Precompile one regex per keyword. `\b` on the left only; the right
-// side is unbounded so "engineer" matches "engineer" / "engineering" /
-// "engineers" without each variant being added to the list. Building
-// regexes at module load keeps `isSoftwareRole` allocation-free.
+// Precompile one regex per keyword. The left anchor is `(?:^|\W)` —
+// start-of-string OR any non-word char — rather than `\b`. `\b` only
+// fires on the seam between a word and a non-word character, which
+// silently fails for keywords that themselves start with a non-word
+// char: e.g. for ".net", `\b\.net` would require a word char immediately
+// before the `.`, which is the opposite of what we need to match
+// ".NET Developer" at the start of a title or after a space. This
+// form rejects the original `"ml"` false-positives ("HTML developer"
+// has `t` — a word char — before "ml", so `\W` doesn't match) AND
+// will correctly match a future ".net"-style keyword once added.
+// The right side stays unbounded so "engineer" still matches
+// "engineer" / "engineering" / "engineers" without each variant being
+// added to the list. Building regexes at module load keeps
+// `isSoftwareRole` allocation-free.
 const KEYWORD_REGEXES = SOFTWARE_ROLE_KEYWORDS.map(
-  (kw) => new RegExp(`\\b${escapeRegex(kw)}`, "i"),
+  (kw) => new RegExp(`(?:^|\\W)${escapeRegex(kw)}`, "i"),
 );
 
 export function isSoftwareRole(title) {


### PR DESCRIPTION
This pull request introduces several improvements to the experience summary feature, focusing on accessibility, cross-browser visual consistency, and more accurate role detection. It also includes minor code quality enhancements and bug fixes. The most important changes are grouped below by theme.

**Experience Modal Visual and Accessibility Improvements:**

* The experience breakdown modal now uses `dvh` units (with a `vh` fallback) for sizing, ensuring the modal and its scrollable content properly match the visible viewport, especially on iOS Safari, where the URL bar can affect available space. This prevents the modal from appearing to "jump" as the browser chrome changes.
* The modal's scrollable region now uses `overscroll-contain` to prevent scroll chaining, which previously caused the modal panel to slide around on iOS when the inner scroll reached its end.
* The trigger for opening the experience modal only exposes button semantics (role, tabIndex, ARIA attributes, and event handlers) once the experience data has loaded, improving accessibility for assistive technology users and preventing misleading controls.

**Experience Role Detection Accuracy:**

* The software role keyword matching logic now uses word-boundary-aware, case-insensitive regular expressions on the left side of each keyword (e.g., `\bml`), preventing false positives such as matching "ml" in "HTML" or "XML". This ensures only true software-engineering roles are counted. The regexes are precompiled for efficiency, and future keywords with special characters are safely escaped. [[1]](diffhunk://#diff-c2fa6a5fd48b4d944ba4407de07c25c4cfdb313f24f66935570ce7d0dbe29c92L4-R17) [[2]](diffhunk://#diff-c2fa6a5fd48b4d944ba4407de07c25c4cfdb313f24f66935570ce7d0dbe29c92R36-R55)

**Consistency and Code Quality:**

* The experience summary banner now uses the same `formatDuration` helper as the server for formatting total experience, ensuring the display string in the banner always matches the payload's formatting. [[1]](diffhunk://#diff-22e0f99f0b91d5fdfb7558b14f307e6fb9d17fc5061b74da92d958d08408202dR5-R6) [[2]](diffhunk://#diff-22e0f99f0b91d5fdfb7558b14f307e6fb9d17fc5061b74da92d958d08408202dL23-L34) [[3]](diffhunk://#diff-22e0f99f0b91d5fdfb7558b14f307e6fb9d17fc5061b74da92d958d08408202dL55-R50)
* The colour for the "No software-engineering roles detected yet" message in the modal was updated to use the `text-fire-amber` class for improved consistency and visibility.
* In the update banner animation, spaces are now rendered as keyed React Fragments, making the code more robust and future-proof against React changes. [[1]](diffhunk://#diff-8fb7c03be88767013db929f2a9f78485619b62d4a468e9565eae2e76458bd604R3-R4) [[2]](diffhunk://#diff-8fb7c03be88767013db929f2a9f78485619b62d4a468e9565eae2e76458bd604L180-R188)

**Deployment and File Bundling:**

* The Next.js config explicitly includes the resume PDF in the serverless function bundle using `outputFileTracingIncludes`, ensuring the PDF is available at runtime both locally and in production on Vercel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed viewport and display issues on iOS Safari devices
  * Improved animation rendering stability in update notifications

* **Improvements**
  * Enhanced loading state feedback for the experience summary card
  * Refined software role keyword matching and detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MA1002643/theabdullahfolio/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->