### PR TITLE
feat: refactor counter animation to eliminate viewport dependency and ensure initial value display

### DIFF
--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -9,7 +9,6 @@ import ReadmeStatsCard from "./RepoStatsCard";
 import { detectChanges } from "@/utils/diffChanges";
 import { computeRepoDiff } from "@/utils/repoDiff";
 import { useExperienceSummary } from "@/hooks/useExperienceSummary";
-import { useViewportCountTrigger } from "@/hooks/useViewportCountTrigger";
 import { ExperienceBreakdownModal } from "./ExperienceBreakdownModal";
 import { ExperienceUpdateBanner } from "./ExperienceUpdateBanner";
 import { UpdateBanner } from "./UpdateBanner";

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import ItemLayout from "./ItemsLayout";
-import { animate, AnimatePresence, useInView, useScroll, useTransform, useReducedMotion, motion } from "framer-motion";
+import { animate, useInView, useScroll, useTransform, useReducedMotion, motion } from "framer-motion";
 import { projectsData } from "@/app/data";
 import LanguagesCard from "./LanguagesCard";
 import GitHubStatsCard from "./StatsCard";
@@ -225,15 +225,25 @@ const AboutDetails = () => {
   // area, so `playToken` could latch at 0, the effect's
   // `if (playToken === 0) return;` early-return would fire, and the
   // digit `<p>` would stay empty even after `to` (e.g. the years value
-  // from `useExperienceSummary`) arrived. Initial `from` is also
-  // rendered as the JSX text so first paint isn't a blank slot before
-  // the animation's first frame.
+  // from `useExperienceSummary`) arrived.
+  //
+  // Honours `prefers-reduced-motion`: skip the 2 s tween entirely and
+  // write `to` straight to the node — mirrors PercentCount's
+  // contract so vestibular-sensitive users don't get a fresh count-up
+  // replay every time `experienceCounterValue` flips from cached to
+  // live data. The JSX text initialiser uses the same gate so the
+  // first paint is also the final value under reduced motion.
   function Counter({ from, to, plusIcon = true }) {
     const nodeRef = useRef(null);
+    const prefersReducedMotion = useReducedMotion();
 
     useEffect(() => {
       const node = nodeRef.current;
       if (!node) return;
+      if (prefersReducedMotion) {
+        node.textContent = String(to);
+        return;
+      }
 
       const controls = animate(from, to, {
         duration: 2,
@@ -243,11 +253,11 @@ const AboutDetails = () => {
       });
 
       return () => controls.stop();
-    }, [from, to]);
+    }, [from, to, prefersReducedMotion]);
 
     return (
       <div className="flex items-center justify-center">
-        <p ref={nodeRef}>{from}</p>
+        <p ref={nodeRef}>{prefersReducedMotion ? to : from}</p>
         {plusIcon && <p>+</p>}
       </div>
     );

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -218,22 +218,21 @@ const AboutDetails = () => {
     [0, 1]
   );
 
-  // Counter Animation...
-  // Replays the count-up only on real viewport entries (and on `to`
-  // changes from upstream data). `useViewportCountTrigger` absorbs
-  // brief intersection-observer flicker at the viewport edge so a
-  // small scroll oscillation can't restart the animation mid-flight —
-  // same shared trigger now used by RepoStatsCard's MetricRow.
+  // Counter Animation. Drives the count-up from (from, to) directly —
+  // no viewport gate. The earlier `useViewportCountTrigger` variant
+  // failed the same way `PercentCount` did: this Counter is rendered
+  // inside `ItemLayout`, whose `initial={{ scale: 0 }}` entrance
+  // collapses every descendant's IntersectionObserver rect to zero
+  // area, so `playToken` could latch at 0, the effect's
+  // `if (playToken === 0) return;` early-return would fire, and the
+  // digit `<p>` would stay empty even after `to` (e.g. the years value
+  // from `useExperienceSummary`) arrived. Initial `from` is also
+  // rendered as the JSX text so first paint isn't a blank slot before
+  // the animation's first frame.
   function Counter({ from, to, plusIcon = true }) {
     const nodeRef = useRef(null);
-    const sectionRef = useRef(null);
-    const { playToken } = useViewportCountTrigger(sectionRef, { amount: 0.3 });
 
     useEffect(() => {
-      // Pre-trigger: leave the node empty; the count-up will populate
-      // it on the first real entry. No reset on exit — the value
-      // holds until the next real entry cycle.
-      if (playToken === 0) return;
       const node = nodeRef.current;
       if (!node) return;
 
@@ -245,11 +244,11 @@ const AboutDetails = () => {
       });
 
       return () => controls.stop();
-    }, [from, to, playToken]);
+    }, [from, to]);
 
     return (
-      <div ref={sectionRef} className="flex items-center justify-center">
-        <p ref={nodeRef} />
+      <div className="flex items-center justify-center">
+        <p ref={nodeRef}>{from}</p>
         {plusIcon && <p>+</p>}
       </div>
     );


### PR DESCRIPTION
This pull request updates the counter animation logic in the `AboutDetails` component to address issues with how the animation was previously triggered. The new approach ensures the count-up animation always runs correctly, even when the component is rendered inside an animated container that affects its visibility to the IntersectionObserver.

**Counter Animation Improvements:**

* Removed the use of `useViewportCountTrigger` and the associated `playToken` logic from the `Counter` component, ensuring the count-up animation is now driven directly by the `from` and `to` props without relying on viewport entry detection. This fixes a bug where the counter could remain empty if the IntersectionObserver rect was collapsed during entrance animations.
* The initial `from` value is now rendered as the text content of the counter, preventing a blank slot from appearing before the animation starts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Counter animations now properly respect reduced motion accessibility preferences, displaying final values immediately when enabled.

* **Improvements**
  * Enhanced counter animation responsiveness and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MA1002643/theabdullahfolio/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->