### PR TITLE
feat: implement DOMMatrix polyfill and enhance experience data handling for unavailable sources

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,21 +8,19 @@ const nextConfig = {
   // already do for native modules. Without this the route throws
   // `Object.defineProperty called on non-object` at import time.
   //
-  // `@napi-rs/canvas` MUST be externalized too. In Node, pdfjs-dist
-  // self-polyfills the DOM globals it needs (DOMMatrix, ImageData,
-  // Path2D) by loading `@napi-rs/canvas` via
-  // `createRequire(import.meta.url)("@napi-rs/canvas")`. Next's
-  // dependency tracer (@vercel/nft) can't statically resolve that
-  // runtime-created `require`, so without listing it here the package
-  // and its native `.node` binary are never copied into the deployed
-  // function. The require then throws, pdfjs only `warn()`s ("Cannot
-  // polyfill DOMMatrix"), and the next `new DOMMatrix` during text
-  // extraction throws "DOMMatrix is not defined" — which surfaces as an
-  // empty Employment side (0%) on /about in production while working
-  // fine locally (where the platform binary is already hoisted).
-  // Listing it forces Next to externalize + bundle it with its binary.
+  // We deliberately do NOT externalize or bundle `@napi-rs/canvas`. pdfjs
+  // would otherwise need it to polyfill `DOMMatrix`, but that native
+  // package's platform `.node` binary is loaded via a runtime
+  // `createRequire(...)("@napi-rs/canvas")` that @vercel/nft can't trace,
+  // so it was missing from the deployed function and the route crashed
+  // with "DOMMatrix is not defined" — an empty Employment side (0%) on
+  // /about in production. Instead, the parser installs a pure-JS DOMMatrix
+  // on `globalThis` before pdfjs loads (see
+  // src/utils/experience/domMatrixPolyfill.js). pdfjs keeps that, the
+  // canvas require failing becomes a harmless warning, and text extraction
+  // runs identically on every platform with no native binary to bundle.
   experimental: {
-    serverComponentsExternalPackages: ["pdf-parse", "@napi-rs/canvas"],
+    serverComponentsExternalPackages: ["pdf-parse"],
     // Output File Tracing — explicitly bundle the resume PDF with the
     // experience-summary serverless function. By default, Next only
     // ships files referenced from imports; `public/` assets get
@@ -35,37 +33,7 @@ const nextConfig = {
     // path resolves identically in prod. In Next 14.x this option
     // lives under `experimental`; it became top-level in Next 15+.
     outputFileTracingIncludes: {
-      "/api/experience-summary": [
-        "./public/Muhammad_Abdullah_CV.pdf",
-        // @napi-rs/canvas + its platform binary aren't statically
-        // discoverable by @vercel/nft: pdfjs-dist resolves them at
-        // runtime via `createRequire(import.meta.url)("@napi-rs/canvas")`,
-        // and serverComponentsExternalPackages alone wasn't enough to
-        // pull the *Linux* platform binary into the function bundle —
-        // a real preview deployment was returning
-        // `pdfStatus: { message: "DOMMatrix is not defined" }` and an
-        // empty employment side. Explicitly globbing the JS shim AND
-        // the linux-x64-gnu binary subpackage forces the tracer to
-        // copy them. linux-x64-gnu matches Vercel's Amazon Linux 2
-        // build target; switch the suffix if a project moves to
-        // arm64 or a musl runtime.
-        //
-        // Both ROOT and the pdfjs-dist NESTED path are listed because
-        // the override at the package.json level flattens *most* of
-        // the duplication but npm sometimes preserves a nested
-        // optional-dep install (we observed root 0.1.80 + nested
-        // pdfjs-dist 0.1.100 even after a clean install). Node's
-        // resolution walks up from pdfjs-dist's location and would
-        // pick the nested copy first, so tracing only the root path
-        // would leave the production bundle without the file
-        // createRequire actually resolves. Listing both makes the
-        // trace robust regardless of which instance npm produces at
-        // install time on Vercel.
-        "./node_modules/@napi-rs/canvas/**/*",
-        "./node_modules/@napi-rs/canvas-linux-x64-gnu/**/*",
-        "./node_modules/pdfjs-dist/node_modules/@napi-rs/canvas/**/*",
-        "./node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-x64-gnu/**/*",
-      ],
+      "/api/experience-summary": ["./public/Muhammad_Abdullah_CV.pdf"],
     },
   },
   async headers() {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "engines": {
     "node": ">=20.16.0 <21 || >=22.3.0"
   },
-  "overrides": {
-    "@napi-rs/canvas": "0.1.80"
-  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/app/api/experience-summary/route.js
+++ b/src/app/api/experience-summary/route.js
@@ -380,8 +380,15 @@ async function buildExperienceSummary(username) {
     readAndParseResumeWithTimeout(),
   ]);
 
+  // `personalProjects` is reserved as `null` for exactly one meaning: the
+  // GitHub source FAILED (rejected). A successful response with an empty
+  // repo list is a genuine "owns nothing yet" result, not a failure, so it
+  // returns an explicit empty object (months 0, repos []). This mirrors the
+  // employment side ({ months: 0, roles: [] } on a successful-but-empty
+  // resume parse) and lets the client key its "Unavailable" treatment off
+  // `null` without misreporting a zero-repo account as a load failure.
   let personalProjects = null;
-  if (githubResult.status === "fulfilled" && githubResult.value?.length > 0) {
+  if (githubResult.status === "fulfilled") {
     // Repos are ordered DESC by createdAt (see fetchOwnedRepos), so the
     // last element is the oldest — that's the anchor for the months
     // calculation. The full list is exposed to the client so the modal
@@ -389,15 +396,24 @@ async function buildExperienceSummary(username) {
     // the response also folds rename/create/delete events into the
     // payload's `changeFingerprint` (so Phase 5's banner will announce
     // a "new repo detected" change naturally without bespoke wiring).
-    const repos = githubResult.value;
-    const earliest = new Date(repos[repos.length - 1].createdAt);
-    const months = Math.max(0, monthsBetween(earliest, now));
-    personalProjects = {
-      firstRepoDate: earliest.toISOString().slice(0, 10),
-      months,
-      display: formatDuration(months),
-      repos,
-    };
+    const repos = githubResult.value ?? [];
+    if (repos.length > 0) {
+      const earliest = new Date(repos[repos.length - 1].createdAt);
+      const months = Math.max(0, monthsBetween(earliest, now));
+      personalProjects = {
+        firstRepoDate: earliest.toISOString().slice(0, 10),
+        months,
+        display: formatDuration(months),
+        repos,
+      };
+    } else {
+      personalProjects = {
+        firstRepoDate: null,
+        months: 0,
+        display: formatDuration(0),
+        repos: [],
+      };
+    }
   } else if (githubResult.status === "rejected") {
     console.warn(
       "experience-summary: GitHub owned-repos lookup failed:",

--- a/src/components/about/ExperienceBreakdownModal.jsx
+++ b/src/components/about/ExperienceBreakdownModal.jsx
@@ -525,13 +525,20 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
 
   const personalMonths = data?.personalProjects?.months ?? 0;
   const employmentMonths = data?.employment?.months ?? 0;
-  // A `null` side means its source failed to load (GitHub down for
-  // personal; resume PDF missing/parse error for employment) — distinct
-  // from a present-but-empty `{ months: 0 }`. Drives the "Unavailable"
-  // treatment so the modal never renders a load failure as "0+ years" or
-  // "none detected yet". Mirrors ExperienceSplitBar on the about page.
-  const personalAvailable = data?.personalProjects != null;
-  const employmentAvailable = data?.employment != null;
+  // `data` is null while the summary request is still in flight — which is
+  // NOT a source failure. Only mark a source unavailable once a payload has
+  // actually arrived (`summaryLoaded`) and that source came back null;
+  // otherwise a render mid-fetch would show "Unavailable" counts + failure
+  // copy for a merely pending request. (Today the card only opens the modal
+  // once data exists and the body renders only while `open`, so this is
+  // defensive — but it keeps the booleans honest regardless of how the
+  // modal is mounted, matching the about-page guards' `!!experienceData`
+  // gate.) Once loaded, a `null` side means its source failed (GitHub down
+  // for personal; resume parse failure for employment) — distinct from a
+  // present-but-empty `{ months: 0 }`, which still reads as a genuine 0.
+  const summaryLoaded = data != null;
+  const personalAvailable = !summaryLoaded || data.personalProjects != null;
+  const employmentAvailable = !summaryLoaded || data.employment != null;
   const roles = data?.employment?.roles ?? [];
   const repos = data?.personalProjects?.repos ?? [];
   const maxRoleMonths = roles.reduce((m, r) => Math.max(m, r.months), 0);

--- a/src/components/about/ExperienceBreakdownModal.jsx
+++ b/src/components/about/ExperienceBreakdownModal.jsx
@@ -48,7 +48,7 @@ function AnimatedNumber({ value }) {
 // (the modal is conditionally rendered) means each open replays the
 // animation cleanly without a manual reset. Reduced motion lands on
 // the final value with no animation.
-function CategoryCount({ months }) {
+function CategoryCount({ months, unavailable = false }) {
   const value = months >= 12 ? Math.floor(months / 12) : months;
   // Singular when the count is exactly 1, matching RoleBar's plural-
   // aware rendering. Without this the 12–23-month window reads "1+
@@ -61,6 +61,7 @@ function CategoryCount({ months }) {
   const { playToken } = useViewportCountTrigger(sectionRef, { amount: 0.3 });
 
   useEffect(() => {
+    if (unavailable) return;
     const node = nodeRef.current;
     if (!node) return;
     if (prefersReducedMotion) {
@@ -75,7 +76,19 @@ function CategoryCount({ months }) {
       },
     });
     return () => controls.stop();
-  }, [value, playToken, prefersReducedMotion]);
+  }, [value, playToken, prefersReducedMotion, unavailable]);
+
+  // A `null` source (failed to load) reads as "Unavailable", never "0+
+  // years" — same distinction the about-page split bar draws. A parsed-
+  // but-empty side ({ months: 0 }) keeps `unavailable` false and shows a
+  // genuine 0.
+  if (unavailable) {
+    return (
+      <span className="text-base sm:text-lg italic text-fire-amber opacity-70">
+        Unavailable
+      </span>
+    );
+  }
 
   return (
     <span ref={sectionRef} className="inline-flex items-baseline gap-1 tabular-nums">
@@ -512,6 +525,13 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
 
   const personalMonths = data?.personalProjects?.months ?? 0;
   const employmentMonths = data?.employment?.months ?? 0;
+  // A `null` side means its source failed to load (GitHub down for
+  // personal; resume PDF missing/parse error for employment) — distinct
+  // from a present-but-empty `{ months: 0 }`. Drives the "Unavailable"
+  // treatment so the modal never renders a load failure as "0+ years" or
+  // "none detected yet". Mirrors ExperienceSplitBar on the about page.
+  const personalAvailable = data?.personalProjects != null;
+  const employmentAvailable = data?.employment != null;
   const roles = data?.employment?.roles ?? [];
   const repos = data?.personalProjects?.repos ?? [];
   const maxRoleMonths = roles.reduce((m, r) => Math.max(m, r.months), 0);
@@ -649,15 +669,22 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
                     <span
                       aria-hidden="true"
                       className="inline-block w-2.5 h-2.5 rounded-full"
-                      style={{
-                        background: "#ff6d05",
-                        boxShadow: "0 0 8px rgba(255, 109, 5, 0.6)",
-                      }}
+                      style={
+                        personalAvailable
+                          ? {
+                              background: "#ff6d05",
+                              boxShadow: "0 0 8px rgba(255, 109, 5, 0.6)",
+                            }
+                          : { border: "1px solid #ff6d05", opacity: 0.5 }
+                      }
                     />
                     Personal Projects
                   </dt>
                   <dd>
-                    <CategoryCount months={personalMonths} />
+                    <CategoryCount
+                      months={personalMonths}
+                      unavailable={!personalAvailable}
+                    />
                     {repos.length > 0 && (
                       <span className="block text-xs text-[#ffbb55] mt-0.5">
                         <AnimatedNumber value={repos.length} /> owned {repos.length === 1 ? "repository" : "repositories"}
@@ -674,15 +701,22 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
                     <span
                       aria-hidden="true"
                       className="inline-block w-2.5 h-2.5 rounded-full"
-                      style={{
-                        background: "#ffd27d",
-                        boxShadow: "0 0 8px rgba(255, 210, 125, 0.6)",
-                      }}
+                      style={
+                        employmentAvailable
+                          ? {
+                              background: "#ffd27d",
+                              boxShadow: "0 0 8px rgba(255, 210, 125, 0.6)",
+                            }
+                          : { border: "1px solid #ffd27d", opacity: 0.5 }
+                      }
                     />
                     Employment
                   </dt>
                   <dd>
-                    <CategoryCount months={employmentMonths} />
+                    <CategoryCount
+                      months={employmentMonths}
+                      unavailable={!employmentAvailable}
+                    />
                     {roles.length > 0 && (
                       <span className="block text-xs text-[#ffbb55] mt-0.5">
                         <AnimatedNumber value={roles.length} /> {roles.length === 1 ? "role" : "roles"}
@@ -753,7 +787,9 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
                 </>
               ) : (
                 <p className="text-xs text-fire-amber">
-                  No owned repositories detected yet.
+                  {personalAvailable
+                    ? "No owned repositories detected yet."
+                    : "Personal project data couldn’t be loaded right now."}
                 </p>
               )}
             </section>
@@ -805,7 +841,9 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
                 </ul>
               ) : (
                 <p className="text-sm text-fire-amber">
-                  No software-engineering roles detected yet.
+                  {employmentAvailable
+                    ? "No software-engineering roles detected yet."
+                    : "Employment data couldn’t be loaded right now."}
                 </p>
               )}
             </section>

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -110,9 +110,18 @@ function ExperienceSplitBar({
   const effectivePersonal = personalAvailable ? personalMonths : 0;
   const effectiveEmployment = employmentAvailable ? employmentMonths : 0;
   const total = effectivePersonal + effectiveEmployment;
-  if (total === 0) return null;
-  const personalPct = (effectivePersonal / total) * 100;
-  const employmentPct = (effectiveEmployment / total) * 100;
+  // Bail only when there's genuinely nothing to communicate: both sources
+  // loaded and the measured total is zero. When a source is *unavailable*
+  // we must still render so its "Unavailable" row appears — even if the
+  // surviving (measured) side is itself zero (e.g. GitHub down while the
+  // resume parsed but yielded no software roles). Guarding on `total === 0`
+  // alone would swallow exactly that case.
+  if (personalAvailable && employmentAvailable && total === 0) return null;
+  // Percentages are shares of *measured* experience. With a zero measured
+  // total (only reachable here when a side is unavailable), there's no
+  // denominator, so a present-but-empty side reads as a genuine 0%.
+  const personalPct = total > 0 ? (effectivePersonal / total) * 100 : 0;
+  const employmentPct = total > 0 ? (effectiveEmployment / total) * 100 : 0;
 
   return (
     <div className="mt-4 w-full" aria-hidden="true">
@@ -217,6 +226,38 @@ function ExperienceSplitBar({
       </div>
     </div>
   );
+}
+
+// Spoken equivalent of the ExperienceSplitBar legend, for the years card's
+// accessible name. The card is a `role="button"` with an explicit
+// `aria-label`, which makes it a leaf for name computation — its descendant
+// text (the visual, aria-hidden legend included) is never announced. So the
+// Personal/Employment split, and crucially the "data unavailable" state,
+// have to be folded into the button's own label or screen-reader users hear
+// only the grand total. Mirrors the bar's denominator logic exactly: an
+// unavailable source is excluded (not counted as zero) and spoken as
+// "data unavailable", while a present-but-empty side speaks a genuine
+// "0 percent". Returns "" when there's nothing to split (no bar shown).
+function buildSplitBreakdownLabel(experienceData) {
+  const personalAvailable = experienceData?.personalProjects != null;
+  const employmentAvailable = experienceData?.employment != null;
+  const personalMonths = experienceData?.personalProjects?.months ?? 0;
+  const employmentMonths = experienceData?.employment?.months ?? 0;
+  const effectivePersonal = personalAvailable ? personalMonths : 0;
+  const effectiveEmployment = employmentAvailable ? employmentMonths : 0;
+  const total = effectivePersonal + effectiveEmployment;
+  // Nothing to announce only when both sources loaded and measured zero —
+  // same gate as ExperienceSplitBar. With a side unavailable we still speak
+  // the split so AT users hear the "data unavailable" distinction even when
+  // the measured side is itself zero.
+  if (personalAvailable && employmentAvailable && total === 0) return "";
+  const personalText = personalAvailable
+    ? `${total > 0 ? Math.round((effectivePersonal / total) * 100) : 0} percent`
+    : "data unavailable";
+  const employmentText = employmentAvailable
+    ? `${total > 0 ? Math.round((effectiveEmployment / total) * 100) : 0} percent`
+    : "data unavailable";
+  return `Experience split: personal projects ${personalText}, employment ${employmentText}.`;
 }
 
 const AboutDetails = () => {
@@ -339,6 +380,26 @@ const AboutDetails = () => {
       : experienceTotalMonths;
   const experienceCounterUnit =
     experienceTotalMonths >= 12 ? "years" : "months";
+  // Spoken Personal/Employment split for the years-card button's accessible
+  // name (the visual legend is decorative + aria-hidden and, being inside a
+  // labelled button, would never be announced on its own). Empty string when
+  // there's no split to read.
+  const experienceSplitLabel = buildSplitBreakdownLabel(experienceData);
+
+  // Render the split bar when there's anything worth communicating: measured
+  // experience to apportion, OR a source that failed to load (so its
+  // "Unavailable" row still appears). Hiding purely on `experienceTotalMonths
+  // > 0` would swallow the case where the measured side is genuinely zero but
+  // the other source is unavailable — e.g. GitHub down while the resume
+  // parsed to no roles. Matches ExperienceSplitBar's own bail condition.
+  const experiencePersonalAvailable =
+    experienceData?.personalProjects != null;
+  const experienceEmploymentAvailable = experienceData?.employment != null;
+  const showExperienceSplit =
+    !!experienceData &&
+    (experienceTotalMonths > 0 ||
+      !experiencePersonalAvailable ||
+      !experienceEmploymentAvailable);
 
   // Years-card-as-button: click / Enter / Space opens the breakdown
   // modal. `experienceTriggerRef` lets the modal return focus to the
@@ -702,7 +763,9 @@ const AboutDetails = () => {
                 tabIndex: 0,
                 "aria-haspopup": "dialog",
                 "aria-expanded": isExperienceModalOpen,
-                "aria-label": `${experienceCounterValue}+ ${experienceCounterUnit} of experience. Activate to open category breakdown.`,
+                "aria-label": `${experienceCounterValue}+ ${experienceCounterUnit} of experience.${
+                  experienceSplitLabel ? ` ${experienceSplitLabel}` : ""
+                } Activate to open category breakdown.`,
                 onClick: openExperienceModal,
                 onKeyDown: handleExperienceTriggerKeyDown,
               }
@@ -769,10 +832,11 @@ const AboutDetails = () => {
               )}
             </h1>
 
-            {/* Two-segment split bar — Personal vs Employment as a share
-                of total. Only renders when we have data (otherwise the
-                segments would both compute to NaN). */}
-            {experienceData && experienceTotalMonths > 0 && (
+            {/* Two-segment split bar — Personal vs Employment as a share of
+                total. Renders when there's measured experience to split OR a
+                source is unavailable (so its "Unavailable" row still shows);
+                hidden only when both sources loaded and measured zero. */}
+            {showExperienceSplit && (
               <ExperienceSplitBar
                 personalMonths={experienceData?.personalProjects?.months ?? 0}
                 employmentMonths={experienceData?.employment?.months ?? 0}
@@ -780,8 +844,8 @@ const AboutDetails = () => {
                 // personal; resume PDF missing/parse error for employment),
                 // distinct from a parsed-but-empty `{ months: 0 }`. Drives
                 // the "Unavailable" treatment instead of a misleading 0%.
-                personalAvailable={experienceData?.personalProjects != null}
-                employmentAvailable={experienceData?.employment != null}
+                personalAvailable={experiencePersonalAvailable}
+                employmentAvailable={experienceEmploymentAvailable}
               />
             )}
 

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -239,6 +239,13 @@ function ExperienceSplitBar({
 // "data unavailable", while a present-but-empty side speaks a genuine
 // "0 percent". Returns "" when there's nothing to split (no bar shown).
 function buildSplitBreakdownLabel(experienceData) {
+  // No payload yet (summary still loading) is not a failure — match the
+  // visual split bar's `!!experienceData` gate and say nothing, rather than
+  // announcing both sources as "data unavailable" before any request has
+  // resolved. Without this guard a null payload would fall through (both
+  // `*Available` false, so the both-loaded bail below never fires) and speak
+  // a spurious double "data unavailable".
+  if (!experienceData) return "";
   const personalAvailable = experienceData?.personalProjects != null;
   const employmentAvailable = experienceData?.employment != null;
   const personalMonths = experienceData?.personalProjects?.months ?? 0;

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -43,11 +43,18 @@ const RevealWord = ({ children, progress, range, reducedMotion }) => {
 // guard returned early before the `animate()` ever ran.
 //
 // Reduced motion still skips the animation and shows the final value.
-function PercentCount({ value }) {
+//
+// `unavailable` short-circuits the whole count-up and renders an
+// "Unavailable" label instead of a percentage. It's how a category whose
+// source failed to load (e.g. employment, when the resume PDF can't be
+// parsed) is distinguished from a genuine 0% — rendering "0%" for missing
+// data would assert "zero experience" when the truth is "couldn't measure".
+function PercentCount({ value, unavailable = false }) {
   const nodeRef = useRef(null);
   const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
+    if (unavailable) return;
     const node = nodeRef.current;
     if (!node) return;
     if (prefersReducedMotion) {
@@ -61,7 +68,15 @@ function PercentCount({ value }) {
       },
     });
     return () => controls.stop();
-  }, [value, prefersReducedMotion]);
+  }, [value, prefersReducedMotion, unavailable]);
+
+  if (unavailable) {
+    return (
+      <span className="italic opacity-60 normal-case tracking-normal">
+        Unavailable
+      </span>
+    );
+  }
 
   return (
     <span className="inline-flex items-baseline">
@@ -77,12 +92,27 @@ function PercentCount({ value }) {
 // two surfaces read as a single visual system. Segments are absolute-
 // positioned tooltips rather than children of a flex so a 0%-share
 // segment doesn't claim layout width.
-function ExperienceSplitBar({ personalMonths, employmentMonths }) {
+function ExperienceSplitBar({
+  personalMonths,
+  employmentMonths,
+  personalAvailable = true,
+  employmentAvailable = true,
+}) {
   const prefersReducedMotion = useReducedMotion();
-  const total = personalMonths + employmentMonths;
+  // When a side's source failed to load its month count is *unknown*, not
+  // zero — so exclude it from the denominator entirely. The surviving side
+  // then reads as 100% of *measured* experience, and the failed row renders
+  // "Unavailable" (below) instead of asserting a misleading 0%. A present-
+  // but-empty side ({ months: 0 }) keeps its `*Available` flag true and
+  // still shows a genuine 0%. Symmetric across both sources: GitHub failing
+  // (personal) is the same misrepresentation as the resume PDF failing
+  // (employment).
+  const effectivePersonal = personalAvailable ? personalMonths : 0;
+  const effectiveEmployment = employmentAvailable ? employmentMonths : 0;
+  const total = effectivePersonal + effectiveEmployment;
   if (total === 0) return null;
-  const personalPct = (personalMonths / total) * 100;
-  const employmentPct = (employmentMonths / total) * 100;
+  const personalPct = (effectivePersonal / total) * 100;
+  const employmentPct = (effectiveEmployment / total) * 100;
 
   return (
     <div className="mt-4 w-full" aria-hidden="true">
@@ -99,27 +129,34 @@ function ExperienceSplitBar({ personalMonths, employmentMonths }) {
             unfilled. Driving the animation from data on mount means
             the bar fills as soon as we know the percentages, not when
             an observer that can't see it agrees. */}
-        <motion.span
-          className="absolute inset-y-0 left-0"
-          style={{
-            background: "#ff6d05",
-            boxShadow: "0 0 10px rgba(255, 109, 5, 0.45)",
-          }}
-          initial={prefersReducedMotion ? { width: `${personalPct}%` } : { width: 0 }}
-          animate={{ width: `${personalPct}%` }}
-          transition={{ duration: 1, ease: "easeOut", delay: 0.2 }}
-        />
-        <motion.span
-          className="absolute inset-y-0"
-          style={{
-            left: `${personalPct}%`,
-            background: "#ffd27d",
-            boxShadow: "0 0 10px rgba(255, 210, 125, 0.45)",
-          }}
-          initial={prefersReducedMotion ? { width: `${employmentPct}%` } : { width: 0 }}
-          animate={{ width: `${employmentPct}%` }}
-          transition={{ duration: 1, ease: "easeOut", delay: 0.4 }}
-        />
+        {/* Each segment is omitted entirely when its source is unavailable —
+            there's no meaningful width to draw, and the surviving segment
+            already fills the bar at 100%. */}
+        {personalAvailable && (
+          <motion.span
+            className="absolute inset-y-0 left-0"
+            style={{
+              background: "#ff6d05",
+              boxShadow: "0 0 10px rgba(255, 109, 5, 0.45)",
+            }}
+            initial={prefersReducedMotion ? { width: `${personalPct}%` } : { width: 0 }}
+            animate={{ width: `${personalPct}%` }}
+            transition={{ duration: 1, ease: "easeOut", delay: 0.2 }}
+          />
+        )}
+        {employmentAvailable && (
+          <motion.span
+            className="absolute inset-y-0"
+            style={{
+              left: `${personalPct}%`,
+              background: "#ffd27d",
+              boxShadow: "0 0 10px rgba(255, 210, 125, 0.45)",
+            }}
+            initial={prefersReducedMotion ? { width: `${employmentPct}%` } : { width: 0 }}
+            animate={{ width: `${employmentPct}%` }}
+            transition={{ duration: 1, ease: "easeOut", delay: 0.4 }}
+          />
+        )}
       </div>
       {/* Stacked legend — two rows of [dot label … percentage]. The
           previous single-row `justify-between` layout cramped the
@@ -135,26 +172,46 @@ function ExperienceSplitBar({ personalMonths, employmentMonths }) {
       >
         <span className="flex items-center justify-between gap-2">
           <span className="flex items-center gap-1.5">
+            {/* Filled dot when measured; hollow ring when unavailable, so
+                a failed source reads as "no data" rather than a real
+                zero-width slice. */}
             <span
               className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
-              style={{ background: "#ff6d05" }}
+              style={
+                personalAvailable
+                  ? { background: "#ff6d05" }
+                  : { border: "1px solid #ff6d05", opacity: 0.5 }
+              }
             />
             <span className="text-fire-amber">Personal</span>
           </span>
           <span style={{ color: "#ff6d05", textShadow: "none" }}>
-            <PercentCount value={Math.round(personalPct)} />
+            <PercentCount
+              value={Math.round(personalPct)}
+              unavailable={!personalAvailable}
+            />
           </span>
         </span>
         <span className="flex items-center justify-between gap-2">
           <span className="flex items-center gap-1.5">
+            {/* Filled dot when measured; hollow ring when unavailable, so
+                the empty employment row reads as "no data" at a glance
+                rather than a real zero-width slice. */}
             <span
               className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
-              style={{ background: "#ffd27d" }}
+              style={
+                employmentAvailable
+                  ? { background: "#ffd27d" }
+                  : { border: "1px solid #ffd27d", opacity: 0.5 }
+              }
             />
             <span className="text-fire-amber">Employment</span>
           </span>
           <span style={{ color: "#ff6d05", textShadow: "none" }}>
-            <PercentCount value={Math.round(employmentPct)} />
+            <PercentCount
+              value={Math.round(employmentPct)}
+              unavailable={!employmentAvailable}
+            />
           </span>
         </span>
       </div>
@@ -719,6 +776,12 @@ const AboutDetails = () => {
               <ExperienceSplitBar
                 personalMonths={experienceData?.personalProjects?.months ?? 0}
                 employmentMonths={experienceData?.employment?.months ?? 0}
+                // A `null` side = its source failed to load (GitHub down for
+                // personal; resume PDF missing/parse error for employment),
+                // distinct from a parsed-but-empty `{ months: 0 }`. Drives
+                // the "Unavailable" treatment instead of a misleading 0%.
+                personalAvailable={experienceData?.personalProjects != null}
+                employmentAvailable={experienceData?.employment != null}
               />
             )}
 

--- a/src/utils/experience/domMatrixPolyfill.js
+++ b/src/utils/experience/domMatrixPolyfill.js
@@ -1,0 +1,124 @@
+// Pure-JS DOMMatrix polyfill for server-side pdfjs text extraction.
+//
+// Why this exists: pdfjs-dist (loaded transitively by `pdf-parse`) needs a
+// global `DOMMatrix` to do the affine transform math behind text
+// positioning. In Node it tries to satisfy that by loading the native
+// `@napi-rs/canvas` package via
+// `createRequire(import.meta.url)("@napi-rs/canvas")` — see
+// node_modules/pdfjs-dist/legacy/build/pdf.mjs around the `if (isNodeJS)`
+// block. That runtime-created `require` is invisible to Next/@vercel/nft's
+// static tracer, so the package's platform-specific `.node` binary often
+// never makes it into the deployed serverless bundle. pdfjs then only
+// `warn()`s that it "Cannot polyfill DOMMatrix", and the *next*
+// `new DOMMatrix(...)` during extraction throws "DOMMatrix is not defined"
+// — which surfaced as an empty Employment side (0%) on /about in
+// production while working locally (where the binary is already hoisted).
+//
+// pdfjs's polyfill is gated on `if (!globalThis.DOMMatrix)`, so defining a
+// correct DOMMatrix here *before* pdfjs is imported makes the whole native
+// dependency unnecessary: pdfjs keeps ours, the canvas `require` failing
+// becomes a harmless warning, and text extraction runs identically on every
+// platform. Verified: with the canvas require forced to fail and only this
+// polyfill present, `getText()` produces byte-identical output to a run
+// with the native binary, and never touches `ImageData`/`Path2D` (those are
+// only needed for actual rendering, which text extraction doesn't do).
+//
+// Only the 2D affine surface pdfjs's text path composes is implemented:
+// construction from a [a,b,c,d,e,f] array / matrix-like object / nothing,
+// plus multiplySelf, preMultiplySelf, translate, scale, and invertSelf.
+class DOMMatrixPolyfill {
+  constructor(init) {
+    this.a = 1;
+    this.b = 0;
+    this.c = 0;
+    this.d = 1;
+    this.e = 0;
+    this.f = 0;
+    if (Array.isArray(init) && init.length >= 6) {
+      [this.a, this.b, this.c, this.d, this.e, this.f] = init;
+    } else if (init && typeof init === "object") {
+      this.a = init.a ?? 1;
+      this.b = init.b ?? 0;
+      this.c = init.c ?? 0;
+      this.d = init.d ?? 1;
+      this.e = init.e ?? 0;
+      this.f = init.f ?? 0;
+    }
+  }
+
+  // this = this * m  (right-multiply)
+  multiplySelf(m) {
+    const a = this.a * m.a + this.c * m.b;
+    const b = this.b * m.a + this.d * m.b;
+    const c = this.a * m.c + this.c * m.d;
+    const d = this.b * m.c + this.d * m.d;
+    const e = this.a * m.e + this.c * m.f + this.e;
+    const f = this.b * m.e + this.d * m.f + this.f;
+    this.a = a;
+    this.b = b;
+    this.c = c;
+    this.d = d;
+    this.e = e;
+    this.f = f;
+    return this;
+  }
+
+  // this = m * this  (left-multiply)
+  preMultiplySelf(m) {
+    const a = m.a * this.a + m.c * this.b;
+    const b = m.b * this.a + m.d * this.b;
+    const c = m.a * this.c + m.c * this.d;
+    const d = m.b * this.c + m.d * this.d;
+    const e = m.a * this.e + m.c * this.f + m.e;
+    const f = m.b * this.e + m.d * this.f + m.f;
+    this.a = a;
+    this.b = b;
+    this.c = c;
+    this.d = d;
+    this.e = e;
+    this.f = f;
+    return this;
+  }
+
+  translate(tx = 0, ty = 0) {
+    return this.multiplySelf({ a: 1, b: 0, c: 0, d: 1, e: tx, f: ty });
+  }
+
+  scale(sx = 1, sy) {
+    if (sy == null) sy = sx;
+    return this.multiplySelf({ a: sx, b: 0, c: 0, d: sy, e: 0, f: 0 });
+  }
+
+  invertSelf() {
+    const det = this.a * this.d - this.b * this.c;
+    if (!det) {
+      this.a = this.b = this.c = this.d = this.e = this.f = NaN;
+      return this;
+    }
+    const a = this.d / det;
+    const b = -this.b / det;
+    const c = -this.c / det;
+    const d = this.a / det;
+    const e = -(a * this.e + c * this.f);
+    const f = -(b * this.e + d * this.f);
+    this.a = a;
+    this.b = b;
+    this.c = c;
+    this.d = d;
+    this.e = e;
+    this.f = f;
+    return this;
+  }
+}
+
+// Install the polyfill on `globalThis` if (and only if) no DOMMatrix is
+// already present. Idempotent and side-effect-light: callers invoke it
+// immediately before importing `pdf-parse` so pdfjs's `if (!globalThis
+// .DOMMatrix)` guard sees ours. Leaving a pre-existing real DOMMatrix
+// (e.g. a future Node runtime, or a platform where the native binary did
+// load) untouched means we never regress an environment that already works.
+export function ensureDomMatrixPolyfill() {
+  if (!globalThis.DOMMatrix) {
+    globalThis.DOMMatrix = DOMMatrixPolyfill;
+  }
+}

--- a/src/utils/experience/domMatrixPolyfill.js
+++ b/src/utils/experience/domMatrixPolyfill.js
@@ -80,13 +80,32 @@ class DOMMatrixPolyfill {
     return this;
   }
 
+  // translate/scale are NON-mutating per the spec (the mutating variants are
+  // translateSelf/scaleSelf, which pdfjs doesn't use): return a fresh matrix
+  // and leave `this` untouched, so a caller that keeps the original
+  // reference isn't silently corrupted. `multiplySelf` stays the only
+  // in-place primitive; here it mutates the copy, not `this`.
   translate(tx = 0, ty = 0) {
-    return this.multiplySelf({ a: 1, b: 0, c: 0, d: 1, e: tx, f: ty });
+    return new DOMMatrixPolyfill(this).multiplySelf({
+      a: 1,
+      b: 0,
+      c: 0,
+      d: 1,
+      e: tx,
+      f: ty,
+    });
   }
 
   scale(sx = 1, sy) {
     if (sy == null) sy = sx;
-    return this.multiplySelf({ a: sx, b: 0, c: 0, d: sy, e: 0, f: 0 });
+    return new DOMMatrixPolyfill(this).multiplySelf({
+      a: sx,
+      b: 0,
+      c: 0,
+      d: sy,
+      e: 0,
+      f: 0,
+    });
   }
 
   invertSelf() {

--- a/src/utils/experience/pdfExperienceParser.js
+++ b/src/utils/experience/pdfExperienceParser.js
@@ -1,3 +1,4 @@
+import { ensureDomMatrixPolyfill } from "./domMatrixPolyfill";
 import { isSoftwareRole } from "./roleKeywords";
 import {
   formatDuration,
@@ -90,6 +91,15 @@ export async function parseExperienceFromPdf(pdfBuffer) {
   // imports route modules in plain Node, before the runtime hint
   // (`export const runtime = "nodejs"`) gets a chance to matter.
   // Deferring the import keeps the route bundleable.
+  //
+  // Install our pure-JS DOMMatrix on `globalThis` *before* the import so
+  // pdfjs-dist's `if (!globalThis.DOMMatrix)` polyfill gate (which runs at
+  // module evaluation, during this dynamic import) keeps ours instead of
+  // depending on the native `@napi-rs/canvas` binary that @vercel/nft can't
+  // reliably trace into the serverless bundle. See domMatrixPolyfill.js for
+  // the full rationale — this is what stops production rendering an empty
+  // "Employment 0%" side when the canvas binary is missing.
+  ensureDomMatrixPolyfill();
   const { PDFParse } = await import("pdf-parse");
   // PDFParse expects a Uint8Array; Node's Buffer is one but the type
   // check inside pdf-parse is stricter than necessary, so the


### PR DESCRIPTION
This pull request improves the handling and display of unavailable experience data (such as when GitHub or the resume PDF cannot be loaded) on the About page and in the Experience Breakdown modal. It ensures that missing data is clearly distinguished from a genuine zero, both visually and in text, by showing "Unavailable" instead of "0" or "0%". Additionally, it now removes unnecessary workarounds for the `@napi-rs/canvas` native dependency in the build configuration, as a pure-JS polyfill is used instead.

**User-facing improvements for unavailable experience data:**

* Updated `ExperienceSplitBar`, `PercentCount`, and `CategoryCount` components to display "Unavailable" and hollow indicator dots when experience data (personal projects or employment) fails to load, instead of showing misleading zeroes. The split bar now omits the unavailable segment and shows the other as 100% of the measured experience. [[1]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26L46-R57) [[2]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26L64-R79) [[3]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26L80-R115) [[4]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R132-R135) [[5]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R146-R147) [[6]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R159) [[7]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R175-R214) [[8]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R779-R784) [[9]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552L51-R51) [[10]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552R64) [[11]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552L78-R91) [[12]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552L652-R687) [[13]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552L677-R719)
* In the Experience Breakdown modal, unavailable data now renders as "Unavailable" with appropriate styling and explanatory messages, rather than "0+ years" or "none detected yet". [[1]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552L756-R792) [[2]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552L808-R846)

**Build and deployment configuration cleanup:**

* Removed all special handling, overrides, and explicit bundling for `@napi-rs/canvas` and its platform binaries in `next.config.mjs` and `package.json`, since a pure-JS DOMMatrix polyfill is now used instead of the native module. This simplifies deployment and avoids issues with missing native binaries. [[1]](diffhunk://#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2L11-R23) [[2]](diffhunk://#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2L38-R36) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-L10)

These changes result in a more robust and user-friendly experience, especially in error scenarios, and a simpler, more reliable deployment process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experience view now differentiates missing vs unavailable data, showing “Unavailable” labels, refined split/legend visuals and accessible breakdown labels.

* **Bug Fixes**
  * More reliable resume PDF parsing in serverless by using a pure‑JS DOMMatrix polyfill to avoid native canvas failures.
  * Personal projects now report an empty result when GitHub succeeds with no repos (vs previously null).

* **Chores**
  * Removed an explicit package pin and narrowed file tracing for a specific API route.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MA1002643/theabdullahfolio/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->