### PR TITLE
feat: enhance language data handling and update banner logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,46 @@ the maintainer's discretion to mark coherent release boundaries.
 
 ## [Unreleased]
 
-_Scope: changes shipped by the Repository Governance & Templates Suite ([#81](https://github.com/MA1002643/theabdullahfolio/pull/81), closing [#23](https://github.com/MA1002643/theabdullahfolio/issues/23)); the Experience Summary live-data feature for the about page (`#102` + `#106`, combined into `feat/experience-summary-combined`); and the Unify Page Titles refactor ([#104](https://github.com/MA1002643/theabdullahfolio/issues/104))._
+_Scope: changes shipped by the Repository Governance & Templates Suite ([#81](https://github.com/MA1002643/theabdullahfolio/pull/81), closing [#23](https://github.com/MA1002643/theabdullahfolio/issues/23)); the Experience Summary live-data feature for the about page (`#102` + `#106`, combined into `feat/experience-summary-combined`); the Unify Page Titles refactor ([#104](https://github.com/MA1002643/theabdullahfolio/issues/104)); and the Most Used Languages enhancement ([#18](https://github.com/MA1002643/theabdullahfolio/issues/18)) — an interactive language card with a per-repo breakdown popover plus languages-fetch resilience._
 
 ### Added
 
+- Interactive **Most Used Languages** card overhaul
+  (`src/components/about/LanguagesCard.jsx`, [#18](https://github.com/MA1002643/theabdullahfolio/issues/18)). Two-way
+  hover/focus spotlight linking each list row to its stacked-bar
+  segment (the active language stays lit, the rest dim + desaturate,
+  and vice-versa); a monospaced rank index plus a `PRIMARY` pill on the
+  dominant language; a one-shot `.lang-bar-sheen` shimmer sweep across
+  the bar on viewport entry; and a `· live from GitHub` meta line under
+  the title that hides whenever the displayed list is stale and returns
+  on the next live fetch.
+- Per-language **repository breakdown popover** in the languages card.
+  Activating a row opens a "Career snapshot"-themed panel listing the
+  repos that use that language with each repo's share of the language's
+  bytes, repo names in the language's own `.text-fire-amber` gradient,
+  a slim share bar, and the card's fast-start/slow-finish count-up on
+  every percentage (started on open, killed on close via the row's
+  unmount). It opens by hover (fine pointer), keyboard focus (input
+  modality is tracked, so an attached keyboard behaves like hover even
+  on a touch device), or tap on touch (re-tap / tap-outside / Escape to
+  close). Portaled to `<body>` to escape the card's `overflow-hidden`,
+  clamped so it never overflows the viewport, and scrolls its repo list
+  internally (`max-height: calc(100dvh - 16px)` flex column) when a
+  breakdown is taller than the available height.
+- `repos: [{ name, url, percentage }]` per-language breakdown on the
+  `/api/github-stats` payload (`src/app/api/github-stats/route.js`) —
+  each repo's share of *that language's* bytes, sorted biggest-first
+  and capped at 12 (`MAX_REPOS_PER_LANGUAGE`). The owned-repos
+  languages query now also selects each repo's `name` + `url`.
+- `src/hooks/useLanguagesUpdateSignal.js` and
+  `src/utils/languageDiff.js` — a per-device "languages changed since
+  this device last saw them" banner signal and the pure
+  fingerprint/diff helper it and the card share. The fingerprint is
+  derived client-side from the language list, so it also works on the
+  bundled fallback and the server/client can't drift.
+- `.lang-bar-sheen` utility in `src/app/globals.css` (reuses the
+  existing `shimmer-sweep` keyframe — one iteration, `both` fill — for
+  the languages-bar entry sweep).
 - Shared `<PageTitle title subtitle id?>` component
   (`src/components/PageTitle.jsx`) consumed by every sub-page header,
   so the font sizes, neon stroke, and flanked pink-neon subtitle
@@ -70,6 +106,23 @@ _Scope: changes shipped by the Repository Governance & Templates Suite ([#81](ht
 
 ### Changed
 
+- `/api/github-stats` no longer blanks the Most Used Languages card on
+  a partial outage. When the languages GraphQL aborts mid-fetch but the
+  user/stats/streaks queries succeed, the route substitutes the bundled
+  snapshot's languages and flags them `languagesFallback: true` (HTTP
+  200, no `_fallback`) instead of caching an empty list for the 10-min
+  TTL. The client (`src/components/about/index.jsx`) treats
+  snapshot/stale languages as a **soft default** — used to populate a
+  cold card for a first-time visitor, but never allowed to overwrite a
+  returning visitor's own (possibly fresher) `localStorage` last-good.
+- Homepage hero name "Muhammad Abdullah" (`src/app/page.js`) pinned
+  back to its original outline-only look via an inline
+  `color: #000e1700` (transparent fill + orange neon stroke + glow).
+  The Unify Page Titles change had switched the shared
+  `.text-glow-stroke-neon` fill to a solid `#ff6d05` for the sub-page
+  headers (ABOUT ME / CONTACT ME), which also filled in the homepage
+  name; the override restores the hollow hero glyphs without touching
+  the now-solid sub-page titles.
 - Page-title treatment unified across `(sub pages)/about`,
   `(sub pages)/projects`, `(sub pages)/contact`, and
   `(sub pages)/qualifications` via the shared `<PageTitle>` component
@@ -134,6 +187,20 @@ _Scope: changes shipped by the Repository Governance & Templates Suite ([#81](ht
 
 ### Fixed
 
+- Most Used Languages card could blank — and then hydrate empty on the
+  next cold load — after a languages-fetch timeout: the empty-but-`200`
+  response overwrote the good list both in memory and in `localStorage`
+  (the `_fallback` guard didn't catch the partial case). The client now
+  treats an empty/snapshot languages list as "no fresh data this fetch"
+  and keeps the last good breakdown, dropping the `live from GitHub`
+  label until a genuine live fetch returns
+  (`src/components/about/index.jsx`).
+- 404 page phantom scroll on mobile portrait (`src/app/globals.css`).
+  `min-h-screen` / `100vh` is measured against the viewport with the
+  mobile address bar hidden, so the single-screen layout could scroll
+  by the toolbar's height with nothing below it. Portrait phones
+  (`max-width: 640px`) now pin `.not-found-bg` to `100svh`; landscape
+  keeps `100vh` + scroll because the short height genuinely needs it.
 - **Production employment 0%** on `/api/experience-summary` (preview
   deployments returned `pdfStatus: { message: "DOMMatrix is not
   defined" }` and an empty Employment side in the Years card and the
@@ -216,6 +283,13 @@ _Scope: changes shipped by the Repository Governance & Templates Suite ([#81](ht
 
 ### Removed
 
+- `languagesFingerprint` field from the `/api/github-stats` response
+  (and its `import` in the route). No client read it — the change
+  signal recomputes the fingerprint locally from the languages list via
+  `src/utils/languageDiff.js` — so it was dead bytes on every cached
+  response. As a side benefit, because the client's `prevStats` never
+  carried the field, its absence stops `detectChanges` from emitting a
+  spurious `languagesFingerprint` diff on every 10-minute poll.
 - Decorative `-` / `–` flanks inside the Qualifications and Contact
   page subtitle strings ("-accomplishments-" / "– get in touch –").
   The shared `<PageTitle>` now ships flank pills on either side of the

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Built without a UI template or design kit, this project demonstrates deep fronte
 | **Aurora Parallax** | Multi-layer scroll + mouse-tilt parallax with `useScroll()` / `useTransform()` depth mapping |
 | **Cinematic Boot Sequence** | Typewriter-style terminal messages with `clipPath` chunk reveals and sequential timing |
 | **Animated GitHub Stats** | Live GraphQL API → animated SVG ring progress, `requestAnimationFrame` counters, diff-based change detection with 10-min polling |
+| **Interactive Language Breakdown** | Most-used-languages card with two-way bar↔list spotlight, rank + `PRIMARY` labelling, and a per-repo breakdown popover — opened by hover, keyboard focus, or tap — showing each repo's share of the language with a fast-start/slow-finish count-up |
 | **Rocket Contact Form** | Multi-phase submit animation — shake → flame flicker → fly-up trail → checkmark spring, integrated with Nodemailer SMTP |
 | **3D Qualifications Carousel** | CSS perspective transforms, `translateZ` depth, `rotateY`, sepia overlay, category filtering |
 | **Ambient Fireflies** | Generative particle system with randomised spawn, duration, and drift paths |
@@ -205,7 +206,7 @@ theabdullahfolio/
 │   │   │   ├── contact/page.js         # Rocket-animated contact form + Nodemailer
 │   │   │   └── qualifications/page.js  # 3D carousel with certificate cards
 │   │   └── api/
-│   │       ├── github-stats/route.js   # GraphQL → cached stats + rank calculation
+│   │       ├── github-stats/route.js   # GraphQL → cached stats + rank + per-repo language breakdown
 │   │       └── send-mail/route.js      # SMTP email handler
 │   ├── components/
 │   │   ├── navigation/                 # Orbital ring — trig positioning, 5 breakpoints
@@ -218,9 +219,12 @@ theabdullahfolio/
 │   │   ├── FireFliesBackground.jsx     # Ambient generative particle system
 │   │   ├── HomeBtn.jsx                 # Fixed, mobile-safe navigation control
 │   │   └── ProjectsBtn.jsx             # Back button for dynamic project routes
+│   ├── hooks/
+│   │   └── useLanguagesUpdateSignal.js # Per-device language-change banner signal
 │   └── utils/
 │       ├── rankCalculator.js           # GitHub developer rank algorithm
 │       ├── diffChanges.js              # State diff detection for live stat updates
+│       ├── languageDiff.js             # Language fingerprint + diff (client-computed)
 │       └── emoji.js                    # Emoji name-to-symbol resolution
 ├── .github/
 │   ├── workflows/
@@ -301,7 +305,7 @@ Set it as `GITHUB_TOKEN` in `.env.local`. The token is server-only — it is nev
 | CDN `s-maxage` / `stale-while-revalidate` / `stale-if-error` | 10 min / 5 min / 24 hr | Edge caches the response and serves stale on upstream errors |
 | `localStorage` last-good payload | until next successful fetch | Hydrates the stat cards on cold page loads so they never render empty |
 
-**5. Fallback on total failure** — if GitHub returns errors, the route serves the bundled snapshot at [src/data/github-stats-fallback.json](src/data/github-stats-fallback.json) with `X-Cache-Status: FALLBACK` (HTTP 200, `_fallback: true`). The client preserves whatever real data it already had on screen rather than overwriting it with the snapshot. To refresh the snapshot, run the dev server, hit the API, and overwrite the file:
+**5. Fallback on total failure** — if GitHub returns errors, the route serves the bundled snapshot at [src/data/github-stats-fallback.json](src/data/github-stats-fallback.json) with `X-Cache-Status: FALLBACK` (HTTP 200, `_fallback: true`). The client preserves whatever real data it already had on screen rather than overwriting it with the snapshot. (A narrower **languages-only** fallback covers the case where just the languages query times out while the rest succeeds — see point 9.) To refresh the snapshot, run the dev server, hit the API, and overwrite the file:
 
 ```bash
 # Write to a tempfile first, then atomically move into place. A direct
@@ -321,6 +325,10 @@ rm /tmp/fallback.json
 **6. Cache invalidation** — both `unstable_cache` layers expire automatically (10 min and 24 hr). To force a refresh sooner, you can either redeploy or call `revalidateTag("github-stats")` / `revalidateTag("most-active-repo")` from a Server Action. There's also a daily cron at `/api/daily-warmup` (defined in [vercel.json](vercel.json), schedule `0 1 * * *` UTC) — a thin orchestrator that calls `/api/repo-refresh` (which invalidates both tags and warms the cache by hitting `/api/github-stats` with a cache-busting query param) and `/api/work-status?bust=1` (which forces a fresh GitHub poll for the live-status header). Consolidated into a single cron because Hobby plans cap daily cron-job count; the two endpoints remain individually invokable with the bearer token for manual triggers.
 
 **7. Cron and warm-up env vars** — `/api/daily-warmup`, `/api/repo-refresh`, and `/api/work-status?bust=1` are all authenticated against `Authorization: Bearer ${CRON_SECRET}`, which Vercel Cron Jobs attaches automatically when `CRON_SECRET` is set in the project's environment variables. The optional `BASE_URL` env var (server-only — *not* `NEXT_PUBLIC_BASE_URL`, which would leak into client bundles) overrides the URL the cron's internal warm-up fetches hit; falls back to `https://${VERCEL_URL}` then `http://localhost:3000`.
+
+**8. Most Used Languages card & per-repo breakdown** — the language card is more than a static list. Each row links two-ways with the stacked bar (hover or keyboard-focus a row to spotlight its segment and dim the rest, and vice-versa), is rank-numbered with a `PRIMARY` tag on the top language, and carries a `· live from GitHub` meta label that disappears whenever the displayed data is stale and returns once a live fetch lands (see point 9). `/api/github-stats` embeds a per-repo breakdown on every language — a `repos: [{ name, url, percentage }]` array giving each repo's share of *that language's* bytes (sorted biggest-first, capped at 12). Activating a row opens a "Career snapshot"-themed popover listing those repos, with the same fast-start/slow-finish count-up the card numbers use on each percentage. It opens by **hover** on a fine pointer, by **keyboard focus** (detected via input modality, so an attached keyboard behaves like hover even on a touch device), or by **tap** on touch (re-tap / tap-outside / Escape to close). The popover is portaled to `<body>` to escape the card's clip, clamps so it never overflows the viewport, and scrolls its repo list internally when a breakdown is taller than the available height.
+
+**9. Languages-only fallback** — distinct from the whole-payload fallback in point 5: when the languages GraphQL aborts mid-fetch but the user/stats/streaks queries succeed, the route substitutes the bundled snapshot's languages and flags them `languagesFallback: true` (HTTP 200, no `_fallback`) instead of serving an empty list that would blank the card and lock in for the 10-min TTL. The client treats those as a **soft default** — used to populate a cold card for a first-time visitor, but never allowed to overwrite a returning visitor's own (possibly fresher) `localStorage` last-good. In both the stale and partial cases the card keeps showing the last good breakdown and drops its `live from GitHub` label until a genuine live fetch returns. The per-language change-detection fingerprint is computed **client-side** from this list (`src/utils/languageDiff.js`), so it keeps working on the fallback and the two sides can't drift — there is no `languagesFingerprint` field on the wire.
 
 ### Commands
 
@@ -393,7 +401,7 @@ upgrade-insecure-requests
 ## 🎬 Animation Inventory
 
 <details>
-<summary><strong>View all 13 custom animations</strong></summary>
+<summary><strong>View all 14 custom animations</strong></summary>
 <br />
 
 | Animation | Technique | Location |
@@ -405,6 +413,7 @@ upgrade-insecure-requests
 | Rocket launch | Multi-phase: shake → flame → fly → checkmark | `contact/Form.jsx` |
 | Stat counters | `requestAnimationFrame` interpolation | `about/StatsCard.jsx` |
 | SVG rank ring | `stroke-dashoffset` spring animation | `about/StatsCard.jsx` |
+| Language count-up & bar sheen | `animate()` fast-start/slow-finish curve + one-shot shimmer sweep on viewport entry | `about/LanguagesCard.jsx` |
 | Firefly drift | `@keyframes` with randomised duration + paths | `FireFliesBackground.jsx` |
 | Loader progress | SVG `stroke-dashoffset` + percentage counter | `loaderWrapper/index.jsx` |
 | Stagger reveals | `staggerChildren` Framer Motion variants | Multiple components |

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -4,7 +4,6 @@ import { calculateRank } from "@/utils/rankCalculator";
 import { unstable_cache } from "next/cache";
 import { NextResponse } from "next/server";
 
-import { languagesFingerprint } from "@/utils/languageDiff";
 import fallbackStats from "@/data/github-stats-fallback.json";
 
 // Pin to Node so `node:async_hooks` (used by the shared-deadline
@@ -229,10 +228,11 @@ const getCachedGithubStats = unstable_cache(
       ),
     ]);
     // Top 10 per issue #18 (the reference top-langs widget uses
-    // langs_count=10). `languagesFingerprint` is a stable signature of the
-    // names + percentages + ranks so the client can cheaply detect a real
-    // change between visits/polls and gate the update banner on it — the
-    // same helper the client uses, so the two can't drift.
+    // langs_count=10). The change-detection fingerprint is computed
+    // CLIENT-side from this list (useLanguagesUpdateSignal → languagesDiff),
+    // not shipped on the payload: deriving it on the client keeps it working
+    // on the bundled fallback too and guarantees the two sides can't drift,
+    // so there's no server-provided `languagesFingerprint` field to carry.
     let topLanguages = languages.slice(0, 10);
 
     // Languages-only degradation guard. When the languages GraphQL aborts
@@ -260,10 +260,9 @@ const getCachedGithubStats = unstable_cache(
 
     return {
       languages: topLanguages,
-      languagesFingerprint: languagesFingerprint(topLanguages),
       // Only present (and true) on the substituted path — omitted entirely
-      // on the normal path so a successful fetch's fingerprint/payload is
-      // byte-identical to before.
+      // on the normal path so a successful fetch's payload is byte-identical
+      // to before.
       ...(languagesFallback ? { languagesFallback: true } : {}),
       stats,
     };

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -3,6 +3,8 @@ import { parseGitHubText } from "@/utils/emoji";
 import { calculateRank } from "@/utils/rankCalculator";
 import { unstable_cache } from "next/cache";
 import { NextResponse } from "next/server";
+
+import { languagesFingerprint } from "@/utils/languageDiff";
 import fallbackStats from "@/data/github-stats-fallback.json";
 
 // Pin to Node so `node:async_hooks` (used by the shared-deadline
@@ -179,6 +181,12 @@ async function githubGraphQL(query, variables, timeoutMs) {
 // at 100 each), so the missing tier is only the soft history-depth boost.
 const MAX_REPO_PAGES = 10;
 
+// Cap on how many repos each language exposes in its per-repo breakdown
+// (the Most Used Languages card's hover popover). Keeps the payload compact
+// — the popover only needs the top contributors, and the breakdown is
+// sorted biggest-first so the cap drops only the long tail of tiny shares.
+const MAX_REPOS_PER_LANGUAGE = 12;
+
 // Derive the set of `owner/name` keys (lowercased) to skip when picking the
 // "most active" feature repo. The GitHub profile-README repo — the one whose
 // owner AND name both match the username — is always excluded, because every
@@ -220,8 +228,43 @@ const getCachedGithubStats = unstable_cache(
         mostActiveRepo?.activityScore ?? 0
       ),
     ]);
+    // Top 10 per issue #18 (the reference top-langs widget uses
+    // langs_count=10). `languagesFingerprint` is a stable signature of the
+    // names + percentages + ranks so the client can cheaply detect a real
+    // change between visits/polls and gate the update banner on it — the
+    // same helper the client uses, so the two can't drift.
+    let topLanguages = languages.slice(0, 10);
+
+    // Languages-only degradation guard. When the languages GraphQL aborts
+    // mid-fetch, `getAllLanguages` returns [] (indistinguishable from a
+    // genuinely empty account — which can't happen on this single-user,
+    // language-bearing site). Caching and serving that empty list would
+    // blank the Most Used Languages card for any visitor without a
+    // client-side last-good snapshot, and the 10-min TTL would lock that
+    // empty state in. So substitute the bundled snapshot's languages and
+    // flag it: the client treats `languagesFallback` languages as a soft
+    // default — used to populate a cold card, but never preferred over the
+    // visitor's OWN (possibly fresher) localStorage last-good. The stats
+    // half succeeded independently, so this stays a partial substitution,
+    // distinct from the GET handler's whole-payload `_fallback`.
+    let languagesFallback = false;
+    if (topLanguages.length === 0) {
+      const snapshot = Array.isArray(fallbackStats.languages)
+        ? fallbackStats.languages.slice(0, 10)
+        : [];
+      if (snapshot.length > 0) {
+        topLanguages = snapshot;
+        languagesFallback = true;
+      }
+    }
+
     return {
-      languages: languages.slice(0, 6),
+      languages: topLanguages,
+      languagesFingerprint: languagesFingerprint(topLanguages),
+      // Only present (and true) on the substituted path — omitted entirely
+      // on the normal path so a successful fetch's fingerprint/payload is
+      // byte-identical to before.
+      ...(languagesFallback ? { languagesFallback: true } : {}),
       stats,
     };
   },
@@ -309,6 +352,8 @@ async function getAllLanguages(username) {
             endCursor
           }
           nodes {
+            name
+            url
             languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
               edges {
                 size
@@ -380,13 +425,23 @@ async function getAllLanguages(username) {
     const repoData = data.user.repositories;
     const repos = repoData.nodes;
 
-    // Aggregate sizes
+    // Aggregate sizes — overall per language AND per-repo. The per-repo map
+    // lets each language expose the breakdown of which repos contribute its
+    // bytes (the Most Used Languages card's hover popover). Keyed by repo
+    // name; each entry also keeps the repo URL for the popover's links.
     for (const repo of repos) {
       for (const { size, node } of repo.languages.edges) {
         if (!languageStats[node.name]) {
-          languageStats[node.name] = { size: 0, color: node.color };
+          languageStats[node.name] = { size: 0, color: node.color, repos: {} };
         }
-        languageStats[node.name].size += size;
+        const entry = languageStats[node.name];
+        entry.size += size;
+        if (repo.name) {
+          if (!entry.repos[repo.name]) {
+            entry.repos[repo.name] = { size: 0, url: repo.url ?? null };
+          }
+          entry.repos[repo.name].size += size;
+        }
       }
     }
 
@@ -415,7 +470,11 @@ async function getAllLanguages(username) {
     return [];
   }
 
-  // Sort and convert to percentage
+  // Sort and convert to percentage. Each language also carries its per-repo
+  // breakdown: for every repo that contains the language, the share of THAT
+  // language's bytes contributed by the repo (so the per-repo percentages sum
+  // to ~100% within the language). Sorted biggest-first and capped to keep the
+  // payload compact.
   return Object.entries(languageStats)
     .sort((a, b) => b[1].size - a[1].size)
     .map(([language, info]) => ({
@@ -423,6 +482,15 @@ async function getAllLanguages(username) {
       color: info.color,
       size: info.size,
       percentage: ((info.size / totalSize) * 100).toFixed(2), // 2 decimal places
+      repos: Object.entries(info.repos || {})
+        .sort((a, b) => b[1].size - a[1].size)
+        .slice(0, MAX_REPOS_PER_LANGUAGE)
+        .map(([name, r]) => ({
+          name,
+          url: r.url,
+          percentage:
+            info.size > 0 ? ((r.size / info.size) * 100).toFixed(2) : "0.00",
+        })),
     }));
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -637,6 +637,27 @@
   }
 }
 
+/* One-shot light sweep across the Most Used Languages stacked bar when it
+   scrolls into view. Reuses the global `shimmer-sweep` keyframe but plays
+   exactly once (iteration-count 1) and keeps its final off-screen position
+   (`both`) so no residual highlight lingers on the bar afterward. The
+   element is rendered only for non-reduced-motion users and keyed on the
+   viewport play-token, so it remounts (and replays) on each true entry. */
+.lang-bar-sheen {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background: linear-gradient(
+    105deg,
+    transparent 42%,
+    rgba(255, 196, 92, 0.5) 50%,
+    transparent 58%
+  );
+  background-size: 200% 100%;
+  animation: shimmer-sweep 1.5s ease-out 0.25s 1 both;
+}
+
 @keyframes bounce-shake {
   0% {
     transform: translateY(0) rotate(0deg);
@@ -1019,6 +1040,24 @@ body[data-modal-open] .control-island {
      rather than a generic black box. */
   background: radial-gradient(ellipse at 50% 40%, #1b100f 0%, #01050b 70%);
   min-height: 100vh;
+}
+
+/* Portrait phones: the 404 is a single-screen layout, but `min-h-screen`
+   / `min-height: 100vh` is measured against the viewport with the mobile
+   browser's address bar HIDDEN. While that bar is visible the page is
+   taller than the visible area, so the user can scroll by exactly the
+   toolbar's height with nothing actually below — a phantom scroll on a
+   page that already fits one screen. Pin to the small-viewport height
+   (`100svh`, the address-bar-VISIBLE height) so it fits exactly. The
+   `<main>` already carries `overflow-hidden`, so pinning the height here
+   removes the document scroll entirely. Landscape is intentionally
+   excluded: at a short landscape height the content genuinely overflows
+   and must stay scrollable to reach the suggestion links. */
+@media (orientation: portrait) and (max-width: 640px) {
+  .not-found-bg {
+    min-height: 100svh;
+    height: 100svh;
+  }
 }
 
 /* ── Glitch text ──

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -35,7 +35,18 @@ export default function Home() {
 
         {/* HEADLINE */}
         <div className="z-40 pb-2 pt-3 text-center sm:pt-5 md:pb-4 md:pt-6 lg:pb-6 lg:pt-8">
-          <h1 className="text-glow-stroke-neon text-center text-[2.6rem] font-[500] uppercase leading-none text-transparent sm:text-[3rem] md:text-[4rem] lg:text-[5rem]">
+          {/* Keep the original outline-only look for the hero name. The
+              shared `.text-glow-stroke-neon` class was later changed (page-
+              titles unification, PR #104) to a SOLID #ff6d05 fill so the
+              sub-page headers (ABOUT ME / CONTACT ME) read as filled glyphs —
+              but the homepage name is meant to stay hollow (transparent fill,
+              orange stroke + glow). This inline `color` restores that prior
+              value (`#000e1700`, fully transparent) for this h1 only, without
+              touching the shared class the sub-page titles now rely on. */}
+          <h1
+            className="text-glow-stroke-neon text-center text-[2.6rem] font-[500] uppercase leading-none text-transparent sm:text-[3rem] md:text-[4rem] lg:text-[5rem]"
+            style={{ color: '#000e1700' }}
+          >
             Muhammad
             <br /> Abdullah
           </h1>

--- a/src/components/about/LanguagesCard.jsx
+++ b/src/components/about/LanguagesCard.jsx
@@ -1,144 +1,739 @@
-import { motion, useInView } from "framer-motion";
-import React, { useRef, useEffect, useState } from "react";
+"use client";
+
+import { animate, motion, useReducedMotion } from "framer-motion";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 
 import { UpdateBanner } from "./UpdateBanner";
 
-export default function LanguagesCard({ data, isUpdated }) {
-    const cardRef = useRef(null);
-    const isInView = useInView(cardRef, { once: false, margin: "-50px" });
+import { useLanguagesUpdateSignal } from "@/hooks/useLanguagesUpdateSignal";
+import { useViewportCountTrigger } from "@/hooks/useViewportCountTrigger";
+import { fastStartSlowFinish } from "@/utils/animationCurves";
 
-    const total = data.reduce((sum, lang) => sum + parseFloat(lang.percentage), 0);
+// Shared count-up window. Every row animates over the same duration with no
+// per-row stagger so all percentages reach their targets *simultaneously*
+// (issue #18) — the easing curve, not a stagger, supplies the visual
+// interest (fast start, eased landing).
+const COUNT_UP_DURATION = 2; // seconds
+// How long the change banner lingers once the section scrolls into view.
+const BANNER_AUTO_HIDE_MS = 4500;
 
-    return (
-        <motion.div
-            ref={cardRef}
-            initial={{ opacity: 0, y: 40 }}
-            animate={isInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 1, ease: "easeOut" }}
-            className="p-5 w-full relative overflow-hidden h-full"
+export default function LanguagesCard({ data, isLive = false }) {
+  const cardRef = useRef(null);
+  const prefersReducedMotion = useReducedMotion();
+
+  // Entry-cycle trigger: increments once per *true* viewport entry and is
+  // immune to the rapid in/out IntersectionObserver flicker that made the
+  // old `useInView`-driven count-up restart mid-scroll (issue #16/17 bug
+  // class). Children animate on `playToken`, not raw visibility.
+  const { isInView, playToken } = useViewportCountTrigger(cardRef, {
+    amount: 0.3,
+    margin: "-50px",
+  });
+
+  const languages = Array.isArray(data) ? data : [];
+  // Denominator for the stacked bar. The normalized list sums to ~100, but
+  // guard against a 0 total (empty list) so segment widths never divide by
+  // zero. `|| 1` keeps the math finite; an empty list renders no segments.
+  const total =
+    languages.reduce((sum, l) => sum + parseFloat(l.percentage || 0), 0) || 1;
+
+  // Two-way spotlight link between the list and the stacked bar. Hovering
+  // (or keyboard-focusing) a row, or hovering a bar segment, sets the active
+  // index; every *other* row + segment dims so the active language reads as
+  // a measured highlight rather than a flat list. `null` = nothing active.
+  const [activeIndex, setActiveIndex] = useState(null);
+
+  // Per-language repo-breakdown popover. `popover` holds the active language
+  // index, the anchor row's viewport rect (the portal uses it for fixed
+  // positioning, escaping this card's `overflow-hidden`), and the interaction
+  // `mode`:
+  //   - "hover" — opened by a fine pointer hovering or by keyboard focus.
+  //     Closes on leave/blur (with a short grace delay so the pointer can
+  //     cross the gap into the popover to reach the repo links).
+  //   - "tap"   — opened by a tap on a touch device. Sticky: stays open until
+  //     a tap outside, a tap on another row, a re-tap of the same row, or
+  //     Escape. Ignores leave/blur so a tap doesn't immediately dismiss it.
+  const [popover, setPopover] = useState(null);
+  const closeTimerRef = useRef(null);
+
+  // Hover capability — true only for a fine pointer that can hover (desktop
+  // mouse, or a tablet/phone with a trackpad). On a touch-only phone/tablet
+  // this is false, so the card switches to tap-to-open. Same media query the
+  // 404 page uses to gate its pointer affordances.
+  const [canHover, setCanHover] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia("(hover: hover) and (pointer: fine)");
+    const update = () => setCanHover(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  // Last-input modality. A keyboard attached to a touch device has no hover
+  // pointer, so focus-driven opening can't key off `canHover`; instead we
+  // track whether the most recent interaction was the keyboard (Tab) and, if
+  // so, treat focus like hover — satisfying "keyboard attached → hover
+  // behaviour" even on a phone/tablet.
+  const keyboardModalityRef = useRef(false);
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Tab") keyboardModalityRef.current = true;
+    };
+    const onPointer = () => {
+      keyboardModalityRef.current = false;
+    };
+    window.addEventListener("keydown", onKey, true);
+    window.addEventListener("pointerdown", onPointer, true);
+    window.addEventListener("touchstart", onPointer, true);
+    return () => {
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("pointerdown", onPointer, true);
+      window.removeEventListener("touchstart", onPointer, true);
+    };
+  }, []);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const hasBreakdown = useCallback(
+    (index) => {
+      const lang = languages[index];
+      // Stale/snapshot payloads (and the bundled fallback) carry no per-repo
+      // breakdown — skip the popover rather than show an empty panel.
+      return !!lang && Array.isArray(lang.repos) && lang.repos.length > 0;
+    },
+    [languages],
+  );
+
+  // Open in "hover" mode (fine-pointer hover or keyboard focus).
+  const openHover = useCallback(
+    (index, anchorEl) => {
+      cancelClose();
+      if (!hasBreakdown(index)) return;
+      setPopover({ index, rect: anchorEl.getBoundingClientRect(), mode: "hover" });
+    },
+    [cancelClose, hasBreakdown],
+  );
+
+  // Toggle in "tap" mode (touch). Re-tapping the open row closes it.
+  const toggleTap = useCallback(
+    (index, anchorEl) => {
+      cancelClose();
+      if (!hasBreakdown(index)) {
+        setPopover(null);
+        return;
+      }
+      setPopover((cur) =>
+        cur && cur.index === index && cur.mode === "tap"
+          ? null
+          : { index, rect: anchorEl.getBoundingClientRect(), mode: "tap" },
+      );
+    },
+    [cancelClose, hasBreakdown],
+  );
+
+  // Grace-delayed close that only dismisses a HOVER popover — a tap popover
+  // is sticky and ignores leave/blur, so this is a no-op for it.
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimerRef.current = setTimeout(() => {
+      setPopover((cur) => (cur && cur.mode === "tap" ? cur : null));
+    }, 140);
+  }, [cancelClose]);
+
+  // Per-row handlers (mode-gated). Hover/leave only act with a fine pointer;
+  // focus opens only when the keyboard drove it; tap toggles only without
+  // hover. This is what makes touch → tap, keyboard → hover, mouse → hover.
+  const handleRowEnter = useCallback(
+    (index, el) => {
+      if (canHover) openHover(index, el);
+    },
+    [canHover, openHover],
+  );
+  const handleRowFocus = useCallback(
+    (index, el) => {
+      if (keyboardModalityRef.current) openHover(index, el);
+    },
+    [openHover],
+  );
+  const handleRowTap = useCallback(
+    (index, el) => {
+      if (!canHover) toggleTap(index, el);
+    },
+    [canHover, toggleTap],
+  );
+
+  // While a TAP popover is open, a pointerdown anywhere outside it (and
+  // outside any language row, whose own tap handles toggling) dismisses it.
+  useEffect(() => {
+    if (!popover || popover.mode !== "tap") return undefined;
+    const onDown = (e) => {
+      const t = e.target;
+      if (
+        t?.closest &&
+        (t.closest("[data-lang-popover]") || t.closest("[data-lang-row]"))
+      ) {
+        return;
+      }
+      setPopover(null);
+    };
+    document.addEventListener("pointerdown", onDown, true);
+    return () => document.removeEventListener("pointerdown", onDown, true);
+  }, [popover]);
+
+  // Close on page scroll / resize / Escape — the anchor rect is captured once,
+  // so any layout shift would leave the panel floating. A scroll *inside* the
+  // popover's own repo list must NOT close it (that's the overflow-scroll the
+  // popover relies on), so scrolls originating within it are ignored.
+  useEffect(() => {
+    if (!popover) return undefined;
+    const onScroll = (e) => {
+      const t = e.target;
+      if (t?.closest && t.closest("[data-lang-popover]")) return;
+      setPopover(null);
+    };
+    const onResize = () => setPopover(null);
+    const onKey = (e) => {
+      if (e.key === "Escape") setPopover(null);
+    };
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", onResize);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [popover]);
+
+  // Clear any pending close timer on unmount.
+  useEffect(() => () => cancelClose(), [cancelClose]);
+
+  // Change-aware banner. The hook surfaces a contextual message only when
+  // the language stats actually changed since this device last saw them;
+  // we hold it back until the section is in view, then show + auto-hide.
+  const { pendingMessage, consume } = useLanguagesUpdateSignal(languages);
+  const [bannerMessage, setBannerMessage] = useState(null);
+
+  useEffect(() => {
+    if (!pendingMessage || !isInView) return;
+    setBannerMessage(pendingMessage);
+    consume();
+    const timer = setTimeout(() => setBannerMessage(null), BANNER_AUTO_HIDE_MS);
+    return () => clearTimeout(timer);
+  }, [pendingMessage, isInView, consume]);
+
+  return (
+    <motion.div
+      ref={cardRef}
+      initial={{ opacity: 0, y: 40 }}
+      animate={isInView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 1, ease: "easeOut" }}
+      // Border + glow parity with the "Years in the craft" card: the outer
+      // `custom-bg-abt` amber border comes from the `!p-0` ItemLayout
+      // wrapper (index.jsx), and this inner `repo-card-breathe rounded-lg`
+      // layer adds the same baseline + breathing orange glow on the rounded
+      // perimeter — identical structure to the years card's inner div.
+      className="repo-card-breathe rounded-lg p-6 w-full relative overflow-hidden h-full"
+    >
+      <UpdateBanner
+        message={bannerMessage}
+        visible={Boolean(bannerMessage)}
+        srPrefix="Languages update: "
+        variant="elite"
+      />
+
+      {/* Header — title + an analytics-style meta line. */}
+      <div className="mb-5">
+        {/* Title — amber (#ffaa2a), matching the "Years in the craft"
+            eyebrow on the years card. Flat, semibold, no neon glow. */}
+        <h2
+          className="text-xl md:text-2xl text-left font-semibold mb-1"
+          style={{ color: "#ffaa2a", textShadow: "none" }}
         >
-            <UpdateBanner
-                message={isUpdated ? "This table has been updated" : null}
-                visible={isInView}
-                srPrefix="Languages update: "
-            />
+          Most Used Languages
+        </h2>
+        {/* Meta line — frames the card as a live data widget. Count is
+            pluralised; the "· live from GitHub" suffix is shown only when
+            `isLive` (the displayed languages came from a genuine live
+            fetch). On a languages-GraphQL timeout the card keeps showing the
+            last-good / snapshot list, and the suffix is dropped so it never
+            claims "live" over stale data — it returns the moment a live
+            fetch succeeds again. */}
+        <p
+          className="text-[10px] md:text-xs uppercase tracking-[0.18em]"
+          style={{ color: "rgba(255, 170, 42, 0.6)", textShadow: "none" }}
+        >
+          {languages.length} {languages.length === 1 ? "language" : "languages"}
+          {isLive && " · live from GitHub"}
+        </p>
+      </div>
 
-            {/* Header */}
-            <h2 className="text-xl md:text-2xl text-left w-full capitalize text-shadow-neon-orange mb-6">
-                Most Used Languages
-            </h2>
+      {/* Combined horizontal stacked bar — decorative; the list below
+          carries the same data accessibly. `relative` anchors the one-shot
+          sheen overlay; per-segment right borders draw crisp dividers
+          between colours without changing layout width (border-box). */}
+      <div
+        aria-hidden="true"
+        className="relative w-full h-2 md:h-3 rounded-full overflow-hidden flex mb-5 bg-gray-700/30"
+      >
+        {languages.map((lang, idx) => (
+          <AnimatedBarSegment
+            key={lang.language ?? idx}
+            lang={lang}
+            total={total}
+            playToken={playToken}
+            prefersReducedMotion={prefersReducedMotion}
+            showDivider={idx < languages.length - 1}
+            dimmed={activeIndex !== null && activeIndex !== idx}
+            onActivate={() => setActiveIndex(idx)}
+            onDeactivate={() => setActiveIndex(null)}
+          />
+        ))}
+        {/* One-shot light sweep on entry. Keyed on `playToken` so it
+            remounts (and replays) on each true viewport entry; skipped
+            entirely for reduced-motion users. */}
+        {playToken > 0 && !prefersReducedMotion && (
+          <span key={playToken} className="lang-bar-sheen" aria-hidden="true" />
+        )}
+      </div>
 
-            {/* Combined horizontal stacked bar */}
-            <div className="w-full h-2 md:h-3 rounded-full overflow-hidden flex mb-5 bg-gray-700/30">
-                {data.map((lang, idx) => (
-                    <AnimatedBarSegment
-                        key={idx}
-                        lang={lang}
-                        idx={idx}
-                        total={total}
-                        isInView={isInView}
-                    />
-                ))}
-            </div>
+      {/* Language list — 1 column on mobile, 2 columns on the full-width
+          tablet view (`sm`–`md`), then back to 1 column at `lg`+ where the
+          card becomes half-width and sits beside the taller GitHub-stats
+          card. The single column there stacks all rows so the list fills the
+          stretched card height instead of leaving a gap below a short
+          2-column (3-row) grid. */}
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-y-3 gap-x-4 pt-2 text-sm md:text-base">
+        {languages.map((lang, idx) => (
+          <AnimatedLangLabel
+            key={lang.language ?? idx}
+            lang={lang}
+            rank={idx + 1}
+            isPrimary={idx === 0}
+            playToken={playToken}
+            prefersReducedMotion={prefersReducedMotion}
+            active={activeIndex === idx}
+            dimmed={activeIndex !== null && activeIndex !== idx}
+            onActivate={() => setActiveIndex(idx)}
+            onDeactivate={() => setActiveIndex(null)}
+            onRepoEnter={(el) => handleRowEnter(idx, el)}
+            onRepoFocus={(el) => handleRowFocus(idx, el)}
+            onRepoTap={(el) => handleRowTap(idx, el)}
+            onRepoClose={scheduleClose}
+          />
+        ))}
+      </ul>
 
-            {/* List of languages and percentages */}
-            <div className="grid grid-cols-2 gap-y-3 gap-x-4 pt-2 text-sm md:text-base">
-                {data.map((lang, idx) => (
-                    <AnimatedLangLabel
-                        key={idx}
-                        lang={lang}
-                        idx={idx}
-                        isInView={isInView}
-                    />
-                ))}
-            </div>
-        </motion.div>
-    );
-}
-
-/* 🔹 Animated bar segment for each language */
-function AnimatedBarSegment({ lang, idx, total, isInView }) {
-    const [width, setWidth] = useState(0);
-    const target = (lang.percentage / total) * 100;
-
-    useEffect(() => {
-        if (isInView) {
-            setWidth(0);
-            const start = performance.now();
-            const duration = 2000; // ms
-
-            const animate = (time) => {
-                const progress = Math.min((time - start) / duration, 1);
-                setWidth(target * progress);
-                if (progress < 1) requestAnimationFrame(animate);
-            };
-
-            const timeout = setTimeout(() => requestAnimationFrame(animate), idx * 150);
-            return () => clearTimeout(timeout);
-        }
-    }, [isInView, target, idx]);
-
-    return (
-        <motion.div
-            style={{
-                backgroundColor: lang.color,
-                boxShadow: `0 0 6px ${lang.color}`,
-            }}
-            className="h-full"
-            animate={{ width: `${width}%` }}
-            transition={{ duration: 0.2 }}
+      {/* Repo-breakdown popover — portaled to <body> so it escapes the card's
+          `overflow-hidden`. Rendered only while a row with a known breakdown
+          is hovered/focused. */}
+      {popover && languages[popover.index] && (
+        <LanguageRepoPopover
+          lang={languages[popover.index]}
+          anchorRect={popover.rect}
+          prefersReducedMotion={prefersReducedMotion}
+          // The pointer bridge only matters in hover mode; scheduleClose is a
+          // no-op for a sticky tap popover, so the same handlers are safe for
+          // both. cancelClose keeps a hover popover alive while the pointer is
+          // over it (so its repo links stay reachable).
+          onPointerEnter={cancelClose}
+          onPointerLeave={scheduleClose}
         />
-    );
+      )}
+    </motion.div>
+  );
 }
 
-/* 🔹 Animated language label + percentage counter */
-function AnimatedLangLabel({ lang, idx, isInView }) {
-    const [value, setValue] = useState(0);
-    const target = parseFloat(lang.percentage);
+/* Animated stacked-bar segment. Width drives directly off the DOM node
+   (no per-frame React re-render) and animates 0 → target on each viewport
+   entry cycle with the fast-then-slow curve. The dim/highlight state IS
+   React-controlled (opacity/filter), which is safe alongside the ref-driven
+   width: React diffs `style` per-property, and `width: 0` never changes
+   between renders, so a re-render for the dim state leaves the animated
+   width untouched. */
+function AnimatedBarSegment({
+  lang,
+  total,
+  playToken,
+  prefersReducedMotion,
+  showDivider,
+  dimmed,
+  onActivate,
+  onDeactivate,
+}) {
+  const ref = useRef(null);
+  const target = (parseFloat(lang.percentage || 0) / total) * 100;
 
-    useEffect(() => {
-        if (isInView) {
-            setValue(0);
-            const start = performance.now();
-            const duration = 2000; // ms
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (prefersReducedMotion) {
+      node.style.width = `${target}%`;
+      return;
+    }
+    if (playToken === 0) {
+      // Not yet entered the viewport — sit at 0 so the first entry has a
+      // full 0 → target sweep to play.
+      node.style.width = "0%";
+      return;
+    }
+    const controls = animate(0, target, {
+      duration: COUNT_UP_DURATION,
+      ease: fastStartSlowFinish,
+      onUpdate: (v) => {
+        node.style.width = `${v}%`;
+      },
+    });
+    return () => controls.stop();
+  }, [playToken, target, prefersReducedMotion]);
 
-            const animate = (time) => {
-                const progress = Math.min((time - start) / duration, 1);
-                setValue((target * progress).toFixed(2));
-                if (progress < 1) requestAnimationFrame(animate);
-            };
+  return (
+    <span
+      ref={ref}
+      onMouseEnter={onActivate}
+      onMouseLeave={onDeactivate}
+      className="h-full block flex-shrink-0 cursor-pointer"
+      style={{
+        width: 0,
+        backgroundColor: lang.color,
+        boxShadow: `0 0 6px ${lang.color}`,
+        // Crisp divider between colours. border-box (Tailwind default) keeps
+        // the border *inside* the animated width, so it reads as a thin gap
+        // without pushing the sum past 100% and clipping the last segment.
+        borderRight: showDivider ? "1.5px solid rgba(1, 5, 11, 0.55)" : undefined,
+        opacity: dimmed ? 0.3 : 1,
+        filter: dimmed ? "saturate(0.5)" : "none",
+        transition: "opacity 0.25s ease, filter 0.25s ease",
+      }}
+    />
+  );
+}
 
-            const timeout = setTimeout(() => requestAnimationFrame(animate), idx * 150);
-            return () => clearTimeout(timeout);
-        }
-    }, [isInView, target, idx]);
+/* Animated language row: rank index, colour dot, name, optional PRIMARY tag,
+   and a count-up percentage. The number animates via `textContent` on a ref
+   (matching the about page's PercentCount/Counter pattern) so the 0 → target
+   tween doesn't trigger a React re-render every frame. The row is focusable
+   so keyboard users get the same spotlight as hover; the dim/active styling
+   is React-controlled and, like the bar, doesn't disturb the ref-driven
+   number (the `"0.00"` child is a stable literal React never re-writes). */
+function AnimatedLangLabel({
+  lang,
+  rank,
+  isPrimary,
+  playToken,
+  prefersReducedMotion,
+  active,
+  dimmed,
+  onActivate,
+  onDeactivate,
+  onRepoEnter,
+  onRepoFocus,
+  onRepoTap,
+  onRepoClose,
+}) {
+  const numRef = useRef(null);
+  const target = parseFloat(lang.percentage || 0);
+  const hasRepos = Array.isArray(lang.repos) && lang.repos.length > 0;
 
-    return (
-        <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={isInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.5, delay: idx * 0.1 }}
-            className="flex items-center gap-2"
+  useEffect(() => {
+    const node = numRef.current;
+    if (!node) return;
+    if (prefersReducedMotion) {
+      node.textContent = target.toFixed(2);
+      return;
+    }
+    if (playToken === 0) {
+      node.textContent = "0.00";
+      return;
+    }
+    const controls = animate(0, target, {
+      duration: COUNT_UP_DURATION,
+      ease: fastStartSlowFinish,
+      onUpdate: (v) => {
+        node.textContent = v.toFixed(2);
+      },
+    });
+    return () => controls.stop();
+  }, [playToken, target, prefersReducedMotion]);
+
+  return (
+    <li
+      tabIndex={0}
+      data-lang-row=""
+      // The whole row is the popover trigger, so the name OR the percentage
+      // activates it; the same handlers still drive the bar spotlight.
+      // `currentTarget` (the <li>) is the positioning anchor. Open/close is
+      // mode-gated in the parent: hover/leave act only with a fine pointer,
+      // focus opens only when the keyboard drove it, and tap toggles only on
+      // touch — so touch → tap, keyboard → hover/focus, mouse → hover.
+      onMouseEnter={(e) => {
+        onActivate();
+        onRepoEnter?.(e.currentTarget);
+      }}
+      onMouseLeave={() => {
+        onDeactivate();
+        onRepoClose?.();
+      }}
+      onFocus={(e) => {
+        onActivate();
+        onRepoFocus?.(e.currentTarget);
+      }}
+      onBlur={() => {
+        onDeactivate();
+        onRepoClose?.();
+      }}
+      onClick={(e) => onRepoTap?.(e.currentTarget)}
+      aria-haspopup={hasRepos ? "true" : undefined}
+      className={`group flex items-center gap-2 min-w-0 rounded-md outline-none transition-[opacity,transform] duration-200 ${
+        hasRepos ? "cursor-pointer" : ""
+      }`}
+      style={{
+        opacity: dimmed ? 0.4 : 1,
+        transform: active ? "translateX(2px)" : "none",
+      }}
+    >
+      {/* Rank index — monospaced, dim, fixed-width so the dots/names align
+          into a clean column. Reads like an analytics leaderboard. */}
+      <span
+        aria-hidden="true"
+        className="font-mono tabular-nums text-[10px] md:text-xs select-none w-5 shrink-0"
+        style={{ color: "rgba(255, 170, 42, 0.45)", textShadow: "none" }}
+      >
+        {String(rank).padStart(2, "0")}
+      </span>
+      <span
+        aria-hidden="true"
+        className="w-3 h-3 rounded-full shrink-0"
+        style={{
+          backgroundColor: lang.color,
+          boxShadow: `0 0 4px ${lang.color}`,
+          transform: active ? "scale(1.25)" : "none",
+          transition: "transform 0.2s ease",
+        }}
+      />
+      {/* Language name — fire-amber gradient, matching the "Personal" /
+          "Employment" labels in the Years-in-the-craft split bar. */}
+      <span className="text-fire-amber truncate">{lang.language}</span>
+      {/* PRIMARY tag on the dominant language — a restrained amber pill that
+          marks the headline figure without competing with the percentage. */}
+      {isPrimary && (
+        <span
+          aria-hidden="true"
+          className="ml-1 shrink-0 rounded-full px-1.5 py-[1px] text-[9px] font-semibold uppercase tracking-wider"
+          style={{
+            color: "#ffd27d",
+            background: "rgba(255, 170, 42, 0.08)",
+            border: "1px solid rgba(255, 170, 42, 0.4)",
+            textShadow: "none",
+          }}
         >
-            <span
-                className="w-3 h-3 rounded-full shadow-sm"
+          Primary
+        </span>
+      )}
+      {/* Percentage — flat vivid orange, normal weight + tabular-nums,
+          matching the Personal/Employment numbers in the Years-in-the-craft
+          split bar (size unchanged — inherited from the list). */}
+      <span
+        className="ml-auto tabular-nums shrink-0"
+        style={{ color: "#ff6d05", textShadow: "none" }}
+      >
+        <span ref={numRef}>{prefersReducedMotion ? target.toFixed(2) : "0.00"}</span>%
+      </span>
+    </li>
+  );
+}
+
+/* Repo-breakdown popover for one language. Themed to match the "Career
+   snapshot" experience modal: `custom-bg-abt` amber-bordered panel, inner
+   `repo-card-breathe` glow, amber eyebrow + orange title, `elite-divider`.
+   Portaled to <body> with fixed positioning so it escapes the card's
+   `overflow-hidden`; self-positions beside the anchor row and flips / clamps
+   to stay on-screen. Lists each repo that uses the language with the repo's
+   share of that language's bytes (the shares sum to ~100% within the
+   language). Rendered hidden until measured so it never flashes at its
+   pre-positioned coordinates. */
+function LanguageRepoPopover({
+  lang,
+  anchorRect,
+  prefersReducedMotion,
+  onPointerEnter,
+  onPointerLeave,
+}) {
+  const ref = useRef(null);
+  const [pos, setPos] = useState(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || !anchorRect) return;
+    const MARGIN = 8;
+    const GAP = 12;
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    // Prefer to the right of the row; flip to the left if it would overflow;
+    // pin to the right edge as a last resort on very narrow viewports.
+    let left = anchorRect.right + GAP;
+    if (left + w > vw - MARGIN) left = anchorRect.left - GAP - w;
+    if (left < MARGIN) left = Math.max(MARGIN, vw - w - MARGIN);
+    // Vertically centre on the row, clamped into the viewport.
+    let top = anchorRect.top + anchorRect.height / 2 - h / 2;
+    top = Math.min(Math.max(MARGIN, top), vh - h - MARGIN);
+    setPos({ left, top });
+  }, [anchorRect]);
+
+  const repos = Array.isArray(lang.repos) ? lang.repos : [];
+
+  return createPortal(
+    <div
+      ref={ref}
+      role="group"
+      aria-label={`Repositories using ${lang.language}`}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+      data-lang-popover=""
+      className="custom-bg-abt rounded-xl flex flex-col"
+      style={{
+        position: "fixed",
+        left: pos ? pos.left : -9999,
+        top: pos ? pos.top : -9999,
+        width: 270,
+        maxWidth: "calc(100vw - 16px)",
+        // Never taller than the viewport (dynamic vh accounts for mobile
+        // browser chrome); the repo list inside scrolls to absorb any
+        // overflow rather than the panel running off-screen.
+        maxHeight: "calc(100dvh - 16px)",
+        zIndex: 70,
+        visibility: pos ? "visible" : "hidden",
+        filter: "drop-shadow(0 16px 40px rgba(0, 0, 0, 0.55))",
+      }}
+    >
+      <div className="repo-card-breathe rounded-lg overflow-hidden flex flex-col min-h-0 flex-1">
+        <div className="p-4 flex flex-col min-h-0 flex-1">
+          {/* Header — stays fixed while the repo list below scrolls. */}
+          <div className="shrink-0">
+            {/* Eyebrow — same microlabel treatment as the modal's "Career
+                snapshot". */}
+            <p className="text-[10px] uppercase tracking-[0.22em] text-[#ffaa2a] mb-1">
+              Repository breakdown
+            </p>
+            <h3
+              className="text-sm sm:text-base font-semibold mb-3 flex items-center gap-2"
+              style={{ color: "#ff6d05", textShadow: "none" }}
+            >
+              <span
+                aria-hidden="true"
+                className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
                 style={{
-                    backgroundColor: lang.color,
-                    boxShadow: `0 0 4px ${lang.color}`,
+                  background: lang.color,
+                  boxShadow: `0 0 6px ${lang.color}`,
                 }}
-            ></span>
-            <span
-                className="text-shadow-neon-light-orange"
-                style={{ textShadow: "none" }}
-            >
-                {lang.language}
-            </span>
-            <span
-                className="ml-auto !font-light text-shadow-neon-light-orange"
-                style={{ textShadow: "none" }}
-            >
-                {value}%
-            </span>
-        </motion.div>
-    );
+              />
+              <span className="truncate">{lang.language}</span>
+            </h3>
+            <div aria-hidden="true" className="h-px elite-divider mb-3" />
+          </div>
+          {/* Repo list — scrolls within the viewport-bounded panel so a long
+              breakdown never pushes the popover off-screen. */}
+          <ul className="space-y-2.5 flex-1 min-h-0 overflow-y-auto overscroll-contain pr-0.5">
+            {repos.map((r) => (
+              <li key={r.name} className="text-xs">
+                <div className="flex items-center gap-2">
+                  {r.url ? (
+                    <a
+                      href={r.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      // Repo name in the same fire-amber gradient as the
+                      // language names in the card list. Hover fades slightly —
+                      // a gradient (transparent-fill) text has no visible
+                      // underline colour to shift.
+                      className="text-fire-amber truncate transition-opacity hover:opacity-70"
+                    >
+                      {r.name}
+                    </a>
+                  ) : (
+                    <span className="text-fire-amber truncate">{r.name}</span>
+                  )}
+                  {/* Percentage counts up 0 → target with the card's curve the
+                      moment the popover opens; it's killed if the popover
+                      closes mid-count (this component unmounts and the effect
+                      cleanup stops the tween). */}
+                  <AnimatedRepoPercent
+                    value={r.percentage}
+                    prefersReducedMotion={prefersReducedMotion}
+                  />
+                </div>
+                {/* Slim share bar — uses the language's own colour so the
+                    popover reads as part of the same widget as the card. */}
+                <div className="mt-1 h-1 rounded-full overflow-hidden bg-white/5">
+                  <div
+                    className="h-full rounded-full"
+                    style={{
+                      width: `${Math.min(parseFloat(r.percentage) || 0, 100)}%`,
+                      background: lang.color,
+                      boxShadow: `0 0 5px ${lang.color}`,
+                    }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+/* Count-up percentage for one repo row in the popover. Reuses the card's
+   exact count-up — same `fastStartSlowFinish` curve (sprint to 70%, then the
+   last 30% settles slowly) over the same COUNT_UP_DURATION — driven
+   imperatively on a ref so the tween doesn't re-render every frame. The tween
+   starts on mount (i.e. the moment the popover opens / switches to this repo)
+   and is stopped in the effect cleanup, so closing the popover mid-count
+   unmounts this and kills the animation. Honours reduced motion by painting
+   the final value immediately. */
+function AnimatedRepoPercent({ value, prefersReducedMotion }) {
+  const ref = useRef(null);
+  const target = parseFloat(value) || 0;
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (prefersReducedMotion) {
+      node.textContent = target.toFixed(2);
+      return;
+    }
+    node.textContent = "0.00";
+    const controls = animate(0, target, {
+      duration: COUNT_UP_DURATION,
+      ease: fastStartSlowFinish,
+      onUpdate: (v) => {
+        node.textContent = v.toFixed(2);
+      },
+    });
+    return () => controls.stop();
+  }, [target, prefersReducedMotion]);
+
+  return (
+    <span
+      className="ml-auto tabular-nums shrink-0"
+      style={{ color: "#ff6d05", textShadow: "none" }}
+    >
+      <span ref={ref}>{prefersReducedMotion ? target.toFixed(2) : "0.00"}</span>%
+    </span>
+  );
 }

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -451,12 +451,43 @@ const AboutDetails = () => {
       return;
     }
 
+    // A timed-out languages GraphQL call returns an empty `languages` array
+    // with a 200 — the stats half can still succeed, so the response carries
+    // NO `_fallback` flag and the guard below for it doesn't fire. Treat an
+    // empty list as "no fresh language data this fetch" so it never clobbers
+    // the last good languages already on screen / in the cold-load cache; the
+    // Most Used Languages card keeps showing the most recent successful fetch.
+    const freshLanguages = Array.isArray(data.languages) ? data.languages : [];
+    const hasFreshLanguages = freshLanguages.length > 0;
+    // The server now substitutes the bundled snapshot's languages (flagged
+    // `languagesFallback`) instead of serving an empty list when its own
+    // languages fetch aborted — so a brand-new visitor with no localStorage
+    // still sees a populated card. But those snapshot languages are a static
+    // default: never let them overwrite THIS browser's own (possibly fresher)
+    // last-good in memory or in the cold-load cache. Only a genuine live fetch
+    // is authoritative. New visitors still get the snapshot via the no-prev
+    // first-load branch below, which uses `data.languages` directly.
+    //
+    // `languagesAreAuthoritative` doubles as the "are these languages LIVE?"
+    // signal that drives the card's "live from GitHub" label: true only for a
+    // genuine live fetch — not an empty timeout (`!hasFreshLanguages`), the
+    // partial languages snapshot (`languagesFallback`), or the whole-payload
+    // bundled fallback (`_fallback`). When false, the displayed languages are
+    // kept/stale and the label is dropped until a live fetch returns.
+    const languagesAreAuthoritative =
+      hasFreshLanguages && !data.languagesFallback && !data._fallback;
+
     setGithubStats(prevStats => {
       // If the API served the bundled fallback (upstream failure) and we
       // already have real data on screen, keep that state — only let the
-      // fallback populate on a truly empty first load.
+      // fallback populate on a truly empty first load. Mark `languagesLive`
+      // false since the live source is fully down and we're showing kept
+      // data, so the card drops its "live from GitHub" label. Return a fresh
+      // object only when the flag actually flips, to avoid a needless render.
       if (data._fallback && prevStats) {
-        return prevStats;
+        return prevStats.languagesLive
+          ? { ...prevStats, languagesLive: false }
+          : prevStats;
       }
 
       // First-time load
@@ -468,13 +499,22 @@ const AboutDetails = () => {
           // API reports no qualifying activity. An empty object is truthy and
           // would render a blank "Most Active Repository" card.
           stats: data.stats || { user: {}, stats: {}, streaks: {}, repo: null },
+          // Live only when this first response was a genuine live fetch — a
+          // new visitor served the snapshot starts un-labelled until a live
+          // poll confirms.
+          languagesLive: languagesAreAuthoritative,
         };
       }
 
       // Detect top-level and nested changes
       const diffs = detectChanges(prevStats, data);
 
-      if (diffs.length === 0) return prevStats; // nothing changed
+      // Liveness can flip without the language *values* changing — a timeout
+      // after live data, or a recovery to an identical live list — so the
+      // label state has to reconcile even when the value diff is empty.
+      const livenessChanged =
+        Boolean(prevStats.languagesLive) !== languagesAreAuthoritative;
+      if (diffs.length === 0 && !livenessChanged) return prevStats; // nothing changed
 
       // Compute a human-readable diff for the repo card's update banner.
       // computeRepoDiff returns null on the first-ever change cycle (no prev),
@@ -488,8 +528,15 @@ const AboutDetails = () => {
       const updatedStats = { ...prevStats };
 
       // --- Update top-level languages if changed ---
-      if (diffs.includes("languages")) {
-        updatedStats.languages = data.languages || [];
+      // Only overwrite when the fetch carried *authoritative* (live, non-
+      // snapshot) languages. An empty list means the languages GraphQL timed
+      // out; a `languagesFallback` list is the server's static snapshot. In
+      // both cases keep `prevStats.languages` — already spread into
+      // `updatedStats` — so neither blanks the card nor downgrades a fresher
+      // last-good to the bundled snapshot. A genuinely empty account is a
+      // non-issue on this single-user, language-bearing site.
+      if (diffs.includes("languages") && languagesAreAuthoritative) {
+        updatedStats.languages = freshLanguages;
       }
 
       // --- Update nested stats fields selectively ---
@@ -514,6 +561,12 @@ const AboutDetails = () => {
         };
       }
 
+      // Reconcile the live/stale label state every fetch — independent of the
+      // value diff above, so a timeout (live → stale) or a recovery to an
+      // identical list (stale → live) flips the "live from GitHub" label even
+      // when `updatedStats.languages` itself is unchanged.
+      updatedStats.languagesLive = languagesAreAuthoritative;
+
       return updatedStats;
     });
 
@@ -524,10 +577,26 @@ const AboutDetails = () => {
     // stats with stale snapshot data for every future cold load.
     if (!data?._fallback) {
       try {
+        const statsKey = githubStatsStorageKey(username);
+        // Mirror the in-memory guard for the cold-load cache: never let a
+        // non-authoritative languages list (empty timeout, or the server's
+        // static snapshot) overwrite a better last-good already persisted, or
+        // the next cold load would downgrade/blank the card. Prefer the stored
+        // list when this fetch wasn't authoritative; if nothing is stored yet
+        // (brand-new visitor), fall through to whatever we got — the snapshot
+        // — so their cold reload still hydrates a populated card.
+        let languagesToStore = freshLanguages;
+        if (!languagesAreAuthoritative) {
+          const prevRaw = window.localStorage.getItem(statsKey);
+          const prev = prevRaw ? JSON.parse(prevRaw) : null;
+          if (Array.isArray(prev?.languages) && prev.languages.length > 0) {
+            languagesToStore = prev.languages;
+          }
+        }
         window.localStorage.setItem(
-          githubStatsStorageKey(username),
+          statsKey,
           JSON.stringify({
-            languages: data.languages || [],
+            languages: languagesToStore,
             // `repo: null` (not `{}`) so the parent guard
             // `githubStats?.stats?.repo` correctly suppresses the card on the
             // next cold load when there's no qualifying activity. Must match
@@ -812,7 +881,13 @@ const AboutDetails = () => {
             </p>
 
             <h1
-              className="flex items-baseline gap-2 font-semibold w-full text-left text-2xl sm:text-5xl"
+              // `items-center` (not `items-baseline`): the Counter renders a
+              // flex <div>, which doesn't expose a reliable text baseline to
+              // the parent, so baseline alignment let the big number and the
+              // "… of experience" text drift apart. Centering aligns them
+              // consistently at every width — and matches the sibling
+              // "Completed projects" card, which already uses items-center.
+              className="flex items-center gap-2 font-semibold w-full text-left text-2xl sm:text-5xl"
               style={{ color: "#ff6d05", textShadow: "none" }}
             >
               {experienceData ? (
@@ -873,7 +948,17 @@ const AboutDetails = () => {
         {githubStats?.languages && <ItemLayout
           className={"col-span-full lg:col-span-6 !p-0"}
         >
-          <LanguagesCard data={githubStats.languages} isUpdated={changedFields.includes("languages")} />
+          {/* Update banner is now driven inside LanguagesCard by
+              useLanguagesUpdateSignal (a structured language-diff against the
+              last-seen fingerprint), replacing the old generic
+              changedFields("languages") boolean. */}
+          <LanguagesCard
+            data={githubStats.languages}
+            // Drop the "live from GitHub" label whenever the displayed
+            // languages are kept/stale (a languages-GraphQL timeout or the
+            // bundled snapshot); it returns the moment a live fetch does.
+            isLive={Boolean(githubStats.languagesLive)}
+          />
         </ItemLayout>}
 
         {githubStats?.stats && <ItemLayout className={" col-span-full lg:col-span-6 !p-0"}>

--- a/src/hooks/useLanguagesUpdateSignal.js
+++ b/src/hooks/useLanguagesUpdateSignal.js
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { diffLanguages, languagesFingerprint } from "@/utils/languageDiff";
+
+// Single-user site, so one fixed key suffices. Mirrors the keying
+// discipline of `useExperienceSummary` (which keys per-username) without
+// the extra param — the languages card never receives a username, and the
+// allowlisted endpoint only ever serves the owner's account.
+const STORAGE_KEY = "languages-update:last-seen";
+
+function readStored() {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    // Corrupt entry or storage blocked (private mode) — treat as no
+    // baseline so the banner simply stays silent rather than throwing.
+    return null;
+  }
+}
+
+function writeStored(value) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // QuotaExceeded / private-mode block — we lose the next-visit diff but
+    // the card still renders fine.
+  }
+}
+
+/**
+ * Decides whether the "Most Used Languages" update banner should appear,
+ * based on whether the language stats changed since this device last saw
+ * them.
+ *
+ * Persists the last-seen fingerprint + language list in localStorage. When
+ * the current list's fingerprint differs from the stored one, it diffs the
+ * two (via `diffLanguages`) and surfaces a human-readable `pendingMessage`.
+ * The fingerprint is derived from the data itself (`languagesFingerprint`)
+ * rather than trusting a server-provided field, so it also works on the
+ * bundled fallback payload and can never drift from the server's value
+ * (same helper on both sides).
+ *
+ * Behaviour:
+ *   - First load on a device (no baseline) → record silently, no banner
+ *     (QA: don't announce a "change" when there's nothing to compare to).
+ *   - Fingerprint unchanged → no banner.
+ *   - Fingerprint changed → store new baseline, expose `pendingMessage`.
+ *     The consumer shows it once the section scrolls into view and calls
+ *     `consume()` to clear it.
+ *
+ * The effect keys on the fingerprint *string* (not the array identity), so
+ * it runs only on a genuine data change — re-renders with a fresh-but-
+ * equal array don't re-fire it.
+ *
+ * @param {Array<{language: string, percentage: string|number}>} languages
+ * @returns {{ pendingMessage: string|null, consume: () => void }}
+ */
+export function useLanguagesUpdateSignal(languages) {
+  const [pendingMessage, setPendingMessage] = useState(null);
+
+  // Keep the latest list reachable from the fingerprint-keyed effect
+  // without listing `languages` as a dep (its identity changes every
+  // render and would defeat the fingerprint-only gate).
+  const languagesRef = useRef(languages);
+  languagesRef.current = languages;
+
+  const fingerprint =
+    Array.isArray(languages) && languages.length > 0
+      ? languagesFingerprint(languages)
+      : null;
+
+  useEffect(() => {
+    if (!fingerprint) return;
+    const current = languagesRef.current;
+    const stored = readStored();
+
+    if (!stored) {
+      // No baseline yet — record this snapshot and stay silent.
+      writeStored({ fingerprint, languages: current });
+      return;
+    }
+    if (stored.fingerprint === fingerprint) return; // nothing changed
+
+    const diff = diffLanguages(stored.languages, current);
+    // Advance the baseline immediately so a reload before the user scrolls
+    // doesn't replay the same banner indefinitely. The message lives in
+    // React state until the section becomes visible and the consumer
+    // shows + consumes it.
+    writeStored({ fingerprint, languages: current });
+    if (diff.hasChanges) setPendingMessage(diff.summaryMessage);
+  }, [fingerprint]);
+
+  const consume = useCallback(() => setPendingMessage(null), []);
+
+  return { pendingMessage, consume };
+}

--- a/src/utils/languageDiff.js
+++ b/src/utils/languageDiff.js
@@ -1,0 +1,143 @@
+// Language stats diffing + fingerprinting for the "Most Used Languages"
+// card (issue #18). Pure, framework-agnostic JS so it can be shared by
+// BOTH the server route (/api/github-stats, to expose a stable fingerprint
+// on the payload) and the client hook (useLanguagesUpdateSignal, to decide
+// whether the update banner should appear). Keeping a single source of
+// truth for the fingerprint guarantees the two sides can never drift.
+//
+// Language records have the shape produced by getAllLanguages():
+//   { language: string, color: string, size: number, percentage: string }
+// `percentage` is a 2-decimal string ("12.34"); everything here parses it
+// defensively so a number or string both work.
+
+// Parse a percentage value (string "12.34" or number) to a finite number,
+// falling back to 0 on anything unparseable so a malformed row can't poison
+// the diff with NaN.
+function pct(value) {
+  const n = typeof value === "number" ? value : parseFloat(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Stable fingerprint of a language list — captures both the percentages
+ * and the rank order, so a reorder with identical percentages still
+ * registers as a change. Format: `name:percentage:rank` per language,
+ * pipe-joined. Deterministic for a given list (no hashing needed — the
+ * string itself is the signature and stays compact for the top-N list).
+ *
+ * @param {Array<{language: string, percentage: string|number}>} languages
+ * @returns {string}
+ */
+export function languagesFingerprint(languages) {
+  if (!Array.isArray(languages)) return "";
+  return languages
+    .map((l, i) => `${l?.language ?? ""}:${pct(l?.percentage).toFixed(2)}:${i}`)
+    .join("|");
+}
+
+// 1-based rank for human-facing copy ("#2").
+const rankLabel = (index) => `#${index + 1}`;
+
+/**
+ * Diff a previous language list against the latest one.
+ *
+ * Detects four kinds of change — newly added language, removed language,
+ * percentage delta, and rank movement — and distils them into a single
+ * prioritised `summaryMessage` for the update banner (most headline-worthy
+ * change wins) plus a structured `details` object for any caller that
+ * wants the full picture.
+ *
+ * @param {Array} prev - previously-seen language list (may be null/empty)
+ * @param {Array} next - latest language list
+ * @returns {{
+ *   hasChanges: boolean,
+ *   changeType: "added"|"removed"|"percentage"|"rank"|"none",
+ *   summaryMessage: string|null,
+ *   details: {
+ *     added: string[],
+ *     removed: string[],
+ *     percentChanges: Array<{language: string, from: number, to: number, delta: number}>,
+ *     rankChanges: Array<{language: string, from: number, to: number}>
+ *   }
+ * }}
+ */
+export function diffLanguages(prev, next) {
+  const prevList = Array.isArray(prev) ? prev : [];
+  const nextList = Array.isArray(next) ? next : [];
+
+  const prevByName = new Map(prevList.map((l, i) => [l.language, { ...l, rank: i }]));
+  const nextByName = new Map(nextList.map((l, i) => [l.language, { ...l, rank: i }]));
+
+  const added = nextList
+    .filter((l) => !prevByName.has(l.language))
+    .map((l) => l.language);
+  const removed = prevList
+    .filter((l) => !nextByName.has(l.language))
+    .map((l) => l.language);
+
+  const percentChanges = [];
+  const rankChanges = [];
+  for (const [name, nextEntry] of nextByName) {
+    const prevEntry = prevByName.get(name);
+    if (!prevEntry) continue; // new language — covered by `added`
+    const from = pct(prevEntry.percentage);
+    const to = pct(nextEntry.percentage);
+    // Compare at 2-dp to match the fingerprint's resolution — sub-0.01
+    // float noise shouldn't register as a change.
+    if (from.toFixed(2) !== to.toFixed(2)) {
+      percentChanges.push({ language: name, from, to, delta: to - from });
+    }
+    if (prevEntry.rank !== nextEntry.rank) {
+      rankChanges.push({ language: name, from: prevEntry.rank, to: nextEntry.rank });
+    }
+  }
+
+  const details = { added, removed, percentChanges, rankChanges };
+  const hasChanges =
+    added.length > 0 ||
+    removed.length > 0 ||
+    percentChanges.length > 0 ||
+    rankChanges.length > 0;
+
+  if (!hasChanges) {
+    return { hasChanges: false, changeType: "none", summaryMessage: null, details };
+  }
+
+  // Prioritised single-sentence summary — rarest / most newsworthy first.
+  // 1) A language entering the top list, 2) one dropping out, 3) the
+  // largest percentage move, 4) a rank shuffle.
+  let changeType;
+  let summaryMessage;
+
+  if (added.length === 1) {
+    changeType = "added";
+    summaryMessage = `${added[0]} has been added to the top languages.`;
+  } else if (added.length > 1) {
+    changeType = "added";
+    summaryMessage = `${added.length} new languages entered the top list.`;
+  } else if (removed.length === 1) {
+    changeType = "removed";
+    summaryMessage = `${removed[0]} dropped out of the top languages.`;
+  } else if (removed.length > 1) {
+    changeType = "removed";
+    summaryMessage = `${removed.length} languages dropped out of the top list.`;
+  } else if (percentChanges.length > 0) {
+    changeType = "percentage";
+    // Headline the biggest absolute move.
+    const top = percentChanges.reduce((a, b) =>
+      Math.abs(b.delta) > Math.abs(a.delta) ? b : a,
+    );
+    const dir = top.delta > 0 ? "increased" : "decreased";
+    summaryMessage = `${top.language} ${dir} by ${Math.abs(top.delta).toFixed(1)}%.`;
+  } else {
+    changeType = "rank";
+    const top = rankChanges.reduce((a, b) =>
+      Math.abs(b.to - b.from) > Math.abs(a.to - a.from) ? b : a,
+    );
+    // Lower index = higher rank, so a decrease in index is a move *up*.
+    const dir = top.to < top.from ? "up" : "down";
+    summaryMessage = `${top.language} moved ${dir} to ${rankLabel(top.to)}.`;
+  }
+
+  return { hasChanges: true, changeType, summaryMessage, details };
+}

--- a/src/utils/languageDiff.js
+++ b/src/utils/languageDiff.js
@@ -1,9 +1,9 @@
 // Language stats diffing + fingerprinting for the "Most Used Languages"
-// card (issue #18). Pure, framework-agnostic JS so it can be shared by
-// BOTH the server route (/api/github-stats, to expose a stable fingerprint
-// on the payload) and the client hook (useLanguagesUpdateSignal, to decide
-// whether the update banner should appear). Keeping a single source of
-// truth for the fingerprint guarantees the two sides can never drift.
+// card (issue #18). Pure, framework-agnostic JS. The fingerprint is computed
+// CLIENT-side only: the /api/github-stats route deliberately does NOT ship a
+// `languagesFingerprint` field (see route.js:231-235), so the sole consumer
+// is the client hook (useLanguagesUpdateSignal), which derives the fingerprint
+// from the returned language list to decide whether the update banner appears.
 //
 // Language records have the shape produced by getAllLanguages():
 //   { language: string, color: string, size: number, percentage: string }


### PR DESCRIPTION
This pull request delivers several improvements to the Most Used Languages card, focusing on reliability, user experience, and data integrity. The server now gracefully handles partial failures in the GitHub languages fetch, never blanking the card or overwriting fresher data with stale or fallback values. The client logic is enhanced to distinguish between live, fallback, and timed-out data, ensuring the "live from GitHub" label accurately reflects the card's state. Additional UI and UX tweaks improve polish and consistency across the site.

**Backend: Languages Data Fetching and Fallbacks**
- The server now caps the Most Used Languages card to the top 10 languages, computes a stable fingerprint for change detection, and exposes a per-language breakdown of top contributing repositories (with repo names and URLs) for the card's hover popover. If the languages fetch fails or times out, the server substitutes a bundled snapshot (with a `languagesFallback` flag) instead of returning an empty list, preventing the card from blanking for new visitors. [[1]](diffhunk://#diff-54a0dcd85392a4f0a2cc54f7c0d17d6fe40b27a7045637ddb270306de822cb90R6-R7) [[2]](diffhunk://#diff-54a0dcd85392a4f0a2cc54f7c0d17d6fe40b27a7045637ddb270306de822cb90R184-R189) [[3]](diffhunk://#diff-54a0dcd85392a4f0a2cc54f7c0d17d6fe40b27a7045637ddb270306de822cb90R231-R267) [[4]](diffhunk://#diff-54a0dcd85392a4f0a2cc54f7c0d17d6fe40b27a7045637ddb270306de822cb90R355-R356) [[5]](diffhunk://#diff-54a0dcd85392a4f0a2cc54f7c0d17d6fe40b27a7045637ddb270306de822cb90L383-L389) [[6]](diffhunk://#diff-54a0dcd85392a4f0a2cc54f7c0d17d6fe40b27a7045637ddb270306de822cb90L418-R493)

**Frontend: Data Integrity and Liveness Handling**
- The client now only updates the displayed languages when a genuinely live, authoritative fetch succeeds. It never overwrites fresher data with an empty list (timeout) or the server's fallback snapshot, and only persists authoritative languages to localStorage. The "live from GitHub" label is toggled precisely based on data liveness, independent of content changes. [[1]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R454-R490) [[2]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R502-R517) [[3]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26L491-R539) [[4]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R564-R569) [[5]](diffhunk://#diff-7d1470f7145f6ca03cd339b40929cd45b672cdd72ee42c6ddfe8e78a55775b26R580-R599)

**UI/UX Improvements**
- The Most Used Languages card now receives a one-shot light sweep animation when scrolled into view, enhancing visual feedback.
- The homepage headline restores its intended hollow neon style, independent of recent shared class changes.
- The "years of experience" card aligns its content vertically centered for consistent appearance across breakpoints.
- The 404 page background height is now pinned to the visible viewport on portrait mobile devices, preventing phantom scrolling.
- The `LanguagesCard` now receives an `isLive` prop to control the "live from GitHub" label, reflecting the improved liveness logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive Languages card with per-repository breakdowns, top-10 languages, and change notifications when stats update
* **Bug Fixes**
  * Prevents blanking of the languages card during partial outages and fixes 404 mobile portrait viewport scrolling
* **Style**
  * Added a one-run sheen animation for language bars and restored the homepage hero outline look
* **Documentation**
  * Updated docs and changelog describing the interactive language breakdown and failure-mode behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->