### PR TITLE
feat: enhance Current Streak card with dynamic contributions and update banner for streak changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ the maintainer's discretion to mark coherent release boundaries.
 
 ## [Unreleased]
 
-_Scope: changes shipped by the Repository Governance & Templates Suite ([#81](https://github.com/MA1002643/theabdullahfolio/pull/81), closing [#23](https://github.com/MA1002643/theabdullahfolio/issues/23)); the Experience Summary live-data feature for the about page (`#102` + `#106`, combined into `feat/experience-summary-combined`); the Unify Page Titles refactor ([#104](https://github.com/MA1002643/theabdullahfolio/issues/104)); the Most Used Languages enhancement ([#18](https://github.com/MA1002643/theabdullahfolio/issues/18)) — an interactive language card with a per-repo breakdown popover plus languages-fetch resilience; and the GitHub Stats Section enhancement ([#19](https://github.com/MA1002643/theabdullahfolio/issues/19), [#115](https://github.com/MA1002643/theabdullahfolio/pull/115)) — a redesigned, animated GitHub Stats card with a per-stat change banner, a live/stale label, and a responsive Languages list; and the Completed Projects Section enhancement ([#16](https://github.com/MA1002643/theabdullahfolio/issues/16)) — the completed-projects card rebuilt to match the Years-in-the-Craft card with an animated per-category breakdown bar, a screen-reader summary, a per-device count-change banner, and all about-page count-ups consolidated onto one debounced, flicker-immune hook._
+_Scope: changes shipped by the Repository Governance & Templates Suite ([#81](https://github.com/MA1002643/theabdullahfolio/pull/81), closing [#23](https://github.com/MA1002643/theabdullahfolio/issues/23)); the Experience Summary live-data feature for the about page (`#102` + `#106`, combined into `feat/experience-summary-combined`); the Unify Page Titles refactor ([#104](https://github.com/MA1002643/theabdullahfolio/issues/104)); the Most Used Languages enhancement ([#18](https://github.com/MA1002643/theabdullahfolio/issues/18)) — an interactive language card with a per-repo breakdown popover plus languages-fetch resilience; and the GitHub Stats Section enhancement ([#19](https://github.com/MA1002643/theabdullahfolio/issues/19), [#115](https://github.com/MA1002643/theabdullahfolio/pull/115)) — a redesigned, animated GitHub Stats card with a per-stat change banner, a live/stale label, and a responsive Languages list; and the Completed Projects Section enhancement ([#16](https://github.com/MA1002643/theabdullahfolio/issues/16)) — the completed-projects card rebuilt to match the Years-in-the-Craft card with an animated per-category breakdown bar, a screen-reader summary, a per-device count-change banner, and all about-page count-ups consolidated onto one debounced, flicker-immune hook; and the Current Streak Section enhancement ([#21](https://github.com/MA1002643/theabdullahfolio/issues/21), [#117](https://github.com/MA1002643/theabdullahfolio/pull/117)) — the Current Streak card rebuilt with a server-accurate streak computation, a per-device streak-change update banner, a git-commit-node progress ring with a staggered card entrance, and the Most Used Languages card brought to full entrance-animation parity with the GitHub Stats card (replayable on every viewport entry, with reduced-motion support)._
 
 ### Added
 
@@ -153,6 +153,52 @@ _Scope: changes shipped by the Repository Governance & Templates Suite ([#81](ht
   three time-tiered recourse paths (7-day alternate-channel contact,
   30-day CERT/CC coordination, 90-day responsible-disclosure window)
   and a 48-hour compressed timeline for active-exploitation cases.
+- **Current Streak card overhaul** ([#21](https://github.com/MA1002643/theabdullahfolio/issues/21),
+  [#117](https://github.com/MA1002643/theabdullahfolio/pull/117),
+  `src/components/about/StreakStatsCard.jsx`). Three stat blocks — Total
+  Contributions, the Current Streak progress ring, and Longest Streak —
+  that reveal in a staggered left-to-right cascade on every viewport entry,
+  with vertically-centred content. The ring is a flat-stroke arc whose fill
+  encodes the current streak as a share of the longest, sweeping in once on
+  entry, with a `GitCommitVertical` "commit node" perched at the top. Numbers
+  count up imperatively via the new `animateToTarget` util.
+- `src/hooks/useStreakUpdateSignal.js` + `src/utils/streakDiff.js`
+  (`computeStreakDiff` / `streakFingerprint`) — a per-device "streak stats
+  changed since this device last saw them" banner signal (localStorage
+  baseline, same model as `useLanguagesUpdateSignal` / `useProjectCountSignal`),
+  surfaced via the shared `UpdateBanner` once the card is in view and
+  auto-hidden after ~4.5 s. The fingerprint is computed **client-side** from
+  the three streak values plus the current/longest date ranges (the rolling
+  `totalContributions` range is deliberately excluded so a daily window
+  roll-over never reads as a change), so it works on the bundled fallback and
+  the server/client can't drift.
+- `src/utils/animationCurves.js` — `animateToTarget`, a cancellable
+  `requestAnimationFrame` count-up on the shared fast-start/slow-finish easing
+  (`fastStartSlowFinish`), driving the streak digits. SSR-safe and short-circuits
+  with a no-op fast-path when there is nothing to tween (`from === to`).
+- **Most Used Languages** entrance animation brought to 1:1 parity with the
+  GitHub Stats card (`src/components/about/LanguagesCard.jsx`): a spring
+  `cardVariants` lift, per-character blur-in `AnimatedTitle`, and the language
+  list rows sliding in from the left as a staggered cascade (the Stats card's
+  `metricRowVariants`). All driven off `settledInView` so the whole entrance
+  **replays on every true viewport re-entry**, with a reduced-motion no-op
+  variant set that holds everything still for users who opted out.
+- `settledInView` added to `useViewportCountTrigger` — a debounced, reversible
+  visibility flag (true on a real entry, false only after a *sustained* exit)
+  that drives the GitHub-card entrance fades + per-character titles so they
+  **replay on every re-entry** instead of latching after the first, while still
+  absorbing the `IntersectionObserver` flicker the monotonic `playToken` was
+  introduced to ignore.
+- `src/hooks/useReliableInView.js` — a transform-safe "is this in view?" hook
+  measuring `getBoundingClientRect` (plus a short post-mount `rAF` burst to
+  catch the entrance settling) instead of an `IntersectionObserver`. Needed
+  because an observer attached anywhere inside a `scale: 0 → 1` `ItemLayout`
+  reads zero area at entry and never re-fires after the transform-only
+  scale-up, so the count-ups it gated never ran.
+- Real contribution-calendar total now backs **Total Contributions** in the
+  streak payload (`computeStreaks` in `src/app/api/github-stats/route.js`),
+  replacing the previously hardcoded value so the displayed count and its
+  change-diff are accurate.
 
 ### Changed
 
@@ -437,6 +483,45 @@ _Scope: changes shipped by the Repository Governance & Templates Suite ([#81](ht
   so path-based PR labels stay in sync with the latest diff across the
   PR lifetime, with the welcome job gated by `github.event.action == 'opened'`
   to avoid re-greeting on every push.
+- **Current Streak always reported `0`** ([#21](https://github.com/MA1002643/theabdullahfolio/issues/21),
+  `computeStreaks` in `src/app/api/github-stats/route.js`). GitHub returns the
+  full current *week*, so the calendar was padded with future days at
+  `contributionCount: 0`; scanning forward, the first of those closed the
+  active run and the trailing zeros kept the counter at 0, so the
+  ongoing-streak tail was never reached (the streak read `0` every day except
+  Saturday). The current streak is now found by **walking backward** over days
+  filtered to `<= today`, treating an empty *today* as "not yet broken" (the
+  day isn't over). `end` is pinned to `today` in that case so the range keeps
+  printing **"Present"** and `currentStreak.dateRange` doesn't shift at midnight
+  (which `streakFingerprint` would otherwise read as a real change).
+- **"Projects shipped" / "Years in the craft" count-ups stuck at `0`** on
+  `/about`. Two stacked causes: (1) the `useInView` gating those counters was
+  attached to the `scale: 0 → 1` `ItemLayout`, which reads zero area at entry
+  and never re-fires after the transform settles — replaced with the new
+  `useReliableInView`; and (2) the `Counter` component was defined *inside*
+  `AboutDetails`, so every parent re-render remounted it and reset the tween to
+  0 — hoisted to module scope so it runs once to completion.
+- `streakFingerprint({})` treated the About page's `streaks: {}` loading
+  placeholder as a valid all-zeros snapshot and returned a non-null fingerprint,
+  recording it as a baseline and then firing a **false "updated" banner** the
+  instant real streak data arrived. It now returns `null` for a payload missing
+  every tracked block, so the baseline is only recorded once real data lands.
+- **Repo-breakdown popover dismissed when keyboard focus moved into it**
+  (`src/components/about/LanguagesCard.jsx`). The row's `onBlur` scheduled a
+  close that only a pointer-enter could cancel, so tabbing from a language row
+  to its repo links closed the panel before they were reachable. The row now
+  gates that close on `relatedTarget` (skip it when focus moves into
+  `[data-lang-popover]`), and the popover gained focus enter/leave handlers so
+  it stays open while focus is within it or the trigger row, closing only once
+  focus leaves both.
+- `animateToTarget` scheduled a full ~2 s `requestAnimationFrame` loop of
+  no-op repaints even when `from === to` (reachable from the streak card at a
+  value of 0); a fast-path early return now paints the final value once and
+  finishes synchronously.
+- Reduced motion is now honoured across the **whole** Most Used Languages
+  entrance, not just the title: the card/header/list/row variants swap to a
+  resting no-op set under `prefers-reduced-motion` so nothing springs, slides,
+  or replays for users who opted out.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Built without a UI template or design kit, this project demonstrates deep fronte
 | **Interactive Language Breakdown** | Most-used-languages card with two-way bar↔list spotlight, rank + `PRIMARY` labelling, and a per-repo breakdown popover — opened by hover, keyboard focus, or tap — showing each repo's share of the language with a fast-start/slow-finish count-up; responsive list: top 5 in a single column (mobile → `lg`), up to 10 in two columns at `xl`+ |
 | **Completed Projects Breakdown** | "Projects shipped" card with an animated per-category proportional bar (Web / System, derived from the project data), a `\|`-separated count legend that wraps stacked→side-by-side responsively, count-ups that replay on every viewport entry, and an `sr-only` summary so screen readers get the breakdown |
 | **Years in the Craft** | Experience figure derived live from the earliest GitHub repo **and** software roles parsed from the résumé PDF, with a Personal vs Employment split bar and a click-to-open category breakdown modal |
+| **Current Streak** | Server-accurate streak from the GitHub contribution calendar (future-day-padding aware, "Present"-stable across midnight), shown in a git-commit-node progress ring with a staggered card entrance and a per-device change banner that fires only on real movement |
 | **Rocket Contact Form** | Multi-phase submit animation — shake → flame flicker → fly-up trail → checkmark spring, integrated with Nodemailer SMTP |
 | **3D Qualifications Carousel** | CSS perspective transforms, `translateZ` depth, `rotateY`, sepia overlay, category filtering |
 | **Ambient Fireflies** | Generative particle system with randomised spawn, duration, and drift paths |
@@ -225,14 +226,17 @@ theabdullahfolio/
 │   │   ├── useExperienceSummary.js     # Years-in-the-craft data + localStorage hydration + change signal
 │   │   ├── useLanguagesUpdateSignal.js # Per-device language-change banner signal
 │   │   ├── useProjectCountSignal.js    # Per-device completed-projects count-change banner signal
-│   │   └── useViewportCountTrigger.js  # Latched, hysteresis-debounced "play once per viewport entry" trigger
+│   │   ├── useReliableInView.js        # Transform-safe viewport detection (geometry, not IntersectionObserver)
+│   │   ├── useStreakUpdateSignal.js    # Per-device streak-change banner signal
+│   │   └── useViewportCountTrigger.js  # Latched "play once per entry" trigger + reversible settled-in-view flag
 │   └── utils/
 │       ├── rankCalculator.js           # GitHub developer rank algorithm
 │       ├── diffChanges.js              # State diff detection for live stat updates
 │       ├── languageDiff.js             # Language fingerprint + diff (client-computed)
 │       ├── statsDiff.js                # Per-stat GitHub-stats diff + banner summary
 │       ├── repoDiff.js                 # Most-active-repository change summary
-│       ├── animationCurves.js          # Shared fast-start/slow-finish count-up easing
+│       ├── streakDiff.js               # Streak fingerprint + diff (client-computed)
+│       ├── animationCurves.js          # Shared fast-start/slow-finish easing + imperative count-up (animateToTarget)
 │       ├── experience/                 # Résumé-PDF parsing + experience aggregation helpers
 │       └── emoji.js                    # Emoji name-to-symbol resolution
 ├── .github/
@@ -343,6 +347,8 @@ rm /tmp/fallback.json
 
 **11. Completed Projects & Years-in-the-Craft cards** — the two feature cards beside the About paragraph share the Most Active Repository card's two-layer chrome (outer `custom-bg-abt` amber border + inner `repo-card-breathe` glow). *Completed Projects* renders `projectsData.length` with a count-up plus an animated per-category proportional bar (Web / System today, grouped from each project's `category` once at module scope as `PROJECT_CATEGORY_BREAKDOWN`), a responsive legend (stacked on mobile; side-by-side from `sm` with a vivid `#ff6d05` `|` divider, wrapping back to stacked when the pair won't fit), raw per-category counts, and an `sr-only` "Completed projects by category — …" line so screen readers get the breakdown while the decorative bar + legend stay `aria-hidden`. A per-device `useProjectCountSignal` surfaces a one-time "N new completed projects" banner when the count changes across a deploy. *Years in the Craft* shows the figure from `/api/experience-summary` with a Personal vs Employment split bar and a click-to-open breakdown modal. Every digit on both cards runs through a shared `useViewportCountUp` hook: it animates on a true viewport entry, **replays on re-entry**, and **debounces the out-of-view reset** (`COUNT_RESET_DELAY_MS`) so a brief `IntersectionObserver` flicker during the parent `ItemLayout`'s `scale: 0 → 1` entrance never snaps a number back to 0 — all `prefers-reduced-motion` aware.
 
+**12. Current Streak card** (`src/components/about/StreakStatsCard.jsx`) — three stat blocks (Total Contributions, the Current Streak progress ring, Longest Streak) that reveal in a **staggered left-to-right cascade** on every viewport entry. The ring is a flat-stroke arc whose fill encodes the current streak as a share of the longest, sweeping in once on entry with a `GitCommitVertical` "commit node" at the top; digits count up imperatively via `src/utils/animationCurves.js` `animateToTarget`. Streaks are computed **server-side** in `computeStreaks` (`/api/github-stats`): GitHub pads the contribution calendar with the rest of the current *week*, so future days are dropped (`<= today`) and the current streak is found by walking **backward**, treating an empty *today* as "not yet broken" (and keeping `end` pinned to today so the range reads **"Present"** and doesn't shift at midnight). A per-device `useStreakUpdateSignal` + `src/utils/streakDiff.js` (`computeStreakDiff` / `streakFingerprint`) surfaces a human-readable change banner via the shared `UpdateBanner` only when a tracked value actually moves — the fingerprint is **client-computed** from the streak values + current/longest ranges (the rolling `totalContributions` range is excluded so a daily window roll-over never reads as a change), and an empty `{}` loading placeholder is treated as *absent* so the first real payload doesn't fire a false banner. The adjacent **Most Used Languages** card was brought to full entrance-animation parity with the GitHub Stats card here (spring lift, per-character title, metric-row slide-in stagger), all driven off the reversible `settledInView` flag so the entrance replays on every re-entry, with a reduced-motion no-op path.
+
 ### Commands
 
 ```bash
@@ -414,7 +420,7 @@ upgrade-insecure-requests
 ## 🎬 Animation Inventory
 
 <details>
-<summary><strong>View all 17 custom animations</strong></summary>
+<summary><strong>View all 20 custom animations</strong></summary>
 <br />
 
 | Animation | Technique | Location |
@@ -430,6 +436,9 @@ upgrade-insecure-requests
 | Language count-up & bar sheen | `animate()` fast-start/slow-finish curve + one-shot shimmer sweep on viewport entry | `about/LanguagesCard.jsx` |
 | About count-ups (years, projects total, %s, category counts) | Shared `useViewportCountUp` — `animate()` count-up that replays on viewport entry with a debounced, flicker-immune out-of-view reset | `about/index.jsx` |
 | Experience & projects split bars | Proportional segment widths that re-fill on each viewport entry (`animate` gated on the card's in-view signal) | `about/index.jsx` |
+| GitHub Stats / Languages card entrance | Spring card lift + per-character blur-in title + metric-row slide-in stagger; replays on each viewport entry via the reversible `settledInView` flag, reduced-motion aware | `about/StatsCard.jsx` + `about/LanguagesCard.jsx` |
+| Streak card entrance | Staggered left-to-right section cascade (Total Contributions → Current Streak ring → Longest Streak), replaying on each viewport entry | `about/StreakStatsCard.jsx` |
+| Streak progress ring | `stroke-dashoffset` one-shot fill sweep (current ÷ longest) on entry, with a git-commit node and `animateToTarget` count-ups | `about/StreakStatsCard.jsx` |
 | Firefly drift | `@keyframes` with randomised duration + paths | `FireFliesBackground.jsx` |
 | Loader progress | SVG `stroke-dashoffset` + percentage counter | `loaderWrapper/index.jsx` |
 | Stagger reveals | `staggerChildren` Framer Motion variants | Multiple components |

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -609,7 +609,15 @@ async function fetchGitHubStats(username, repoOwner, repoName, activityScore = 0
   const formatStreakDate = (dateStr) => {
     if (!dateStr) return "N/A";
     const date = new Date(dateStr);
+    // Pin to UTC. The input is a date-only `YYYY-MM-DD` string, which
+    // `new Date(...)` parses as UTC midnight; without `timeZone: "UTC"`,
+    // `toLocaleDateString` renders in the RUNTIME's local zone, so a function
+    // deployed behind UTC would shift the day back one ("Dec 30" → "Dec 29")
+    // and a function ahead of it forward. That makes the emitted `dateRange`
+    // depend on deploy region and reintroduces the very fingerprint
+    // instability this stable formatter exists to remove.
     return date.toLocaleDateString("en-US", {
+      timeZone: "UTC",
       month: "short",
       day: "numeric",
       year: "numeric",

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -908,38 +908,54 @@ async function findMostActiveRepo(username) {
 }
 
 function computeStreaks(contributionCalendar) {
-  const days = contributionCalendar.weeks.flatMap((w) => w.contributionDays);
   const today = new Date().toISOString().slice(0, 10);
 
-  let currentStreak = { days: 0, start: null, end: null };
+  // GitHub returns the FULL current week, so the calendar is padded with the
+  // remaining (future) days of this week at contributionCount 0. Left in, those
+  // trailing zero-days close the running streak before the loop ends AND make
+  // the array's last element a future date — which is exactly why the current
+  // streak was stuck at 0: the loop hit "tomorrow" (count 0), closed the streak
+  // with end = today, and the ongoing-streak tail was never reached. Dropping
+  // everything after today makes the array end on the real "today".
+  const days = contributionCalendar.weeks
+    .flatMap((w) => w.contributionDays)
+    .filter((d) => d.date <= today);
+
+  // --- Longest streak: scan forward, tracking each run's high-water mark. ---
   let longestStreak = { days: 0, start: null, end: null };
-
-  let streak = 0;
-  let streakStart = null;
-
+  let runStart = null;
+  let run = 0;
   for (let i = 0; i < days.length; i++) {
     const { date, contributionCount } = days[i];
     if (contributionCount > 0) {
-      if (streak === 0) streakStart = date;
-      streak++;
+      if (run === 0) runStart = date;
+      run++;
+      if (run > longestStreak.days)
+        longestStreak = { days: run, start: runStart, end: date };
     } else {
-      if (streak > 0) {
-        const streakEnd = days[i - 1].date;
-        if (streak > longestStreak.days)
-          longestStreak = { days: streak, start: streakStart, end: streakEnd };
-        streak = 0;
-      }
+      run = 0;
     }
   }
 
-  // Handle ongoing streak
-  if (streak > 0) {
-    const lastDay = days[days.length - 1].date;
-    if (streak > longestStreak.days)
-      longestStreak = { days: streak, start: streakStart, end: lastDay };
-
-    if (lastDay === today)
-      currentStreak = { days: streak, start: streakStart, end: lastDay };
+  // --- Current streak: walk BACKWARD from the most recent day. ---
+  // An empty TODAY does not break the streak — the day isn't over yet, so the
+  // user may still contribute — so skip an empty today and continue from
+  // yesterday. A gap older than that means the streak is genuinely broken.
+  let currentStreak = { days: 0, start: null, end: null };
+  let i = days.length - 1;
+  if (i >= 0 && days[i].date === today && days[i].contributionCount === 0) {
+    i--; // today not contributed yet — don't count it, but don't break on it
+  }
+  if (i >= 0 && days[i].contributionCount > 0) {
+    const end = days[i].date;
+    let start = end;
+    let count = 0;
+    while (i >= 0 && days[i].contributionCount > 0) {
+      start = days[i].date;
+      count++;
+      i--;
+    }
+    currentStreak = { days: count, start, end };
   }
 
   return { currentStreak, longestStreak };

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -667,7 +667,14 @@ async function fetchGitHubStats(username, repoOwner, repoName, activityScore = 0
         // Real calendar total (was hardcoded to 250) so the count-up and the
         // change-diff in the Current Streak card reflect actual activity.
         value: totalContributions,
-        dateRange: `${formatDate(
+        // Use the UTC-pinned `formatStreakDate` (not `formatDate`) for the
+        // window start: the calendar day is a date-only `YYYY-MM-DD` parsed as
+        // UTC midnight, so the conditional-TZ `formatDate` would render it one
+        // day off depending on the deploy region. This range is excluded from
+        // the streak fingerprint, so it's a display-stability fix only — but it
+        // keeps the shown start day region-independent and consistent with the
+        // streak rows below.
+        dateRange: `${formatStreakDate(
           contributionCalendar.weeks[0].contributionDays[0].date
         )} - Present`,
       },

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -634,7 +634,9 @@ async function fetchGitHubStats(username, repoOwner, repoName, activityScore = 0
     },
     streaks: {
       totalContributions: {
-        value: 250,
+        // Real calendar total (was hardcoded to 250) so the count-up and the
+        // change-diff in the Current Streak card reflect actual activity.
+        value: totalContributions,
         dateRange: `${formatDate(
           contributionCalendar.weeks[0].contributionDays[0].date
         )} - Present`,

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -594,11 +594,33 @@ async function fetchGitHubStats(username, repoOwner, repoName, activityScore = 0
   // Compute streaks
   const { currentStreak, longestStreak } = computeStreaks(contributionCalendar);
 
+  // Streak endpoints are formatted with the year ALWAYS present, unlike the
+  // general `formatDate` (which drops the year for the current year). The
+  // resulting `dateRange` string is what `streakFingerprint`/`computeStreakDiff`
+  // compare across polls to detect a "dates changed" event, so it must shift
+  // ONLY when the underlying dates do. With the conditional-year `formatDate`, a
+  // streak that crosses a New Year boundary reformats at midnight on Jan 1 —
+  // "Dec 30 - Present" → "Dec 30, 2025 - Present" — a purely presentational
+  // change the diff would mis-read as a real date move and surface as a false
+  // "dates changed" banner. (This complements pinning `end` to `today` in
+  // `computeStreaks`, which guards the daily midnight shift; this guards the
+  // yearly one.) Affects the current streak's start and any current-year longest
+  // streak's start/end alike.
+  const formatStreakDate = (dateStr) => {
+    if (!dateStr) return "N/A";
+    const date = new Date(dateStr);
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
   // Replace today's date with "Present" & format
   const formatStreakRange = (start, end) => {
     if (!start || !end) return "No data";
-    const displayEnd = end === today ? "Present" : formatDate(end);
-    return `${formatDate(start)} - ${displayEnd}`;
+    const displayEnd = end === today ? "Present" : formatStreakDate(end);
+    return `${formatStreakDate(start)} - ${displayEnd}`;
   };
 
   // Rank calculation

--- a/src/app/api/github-stats/route.js
+++ b/src/app/api/github-stats/route.js
@@ -943,11 +943,18 @@ function computeStreaks(contributionCalendar) {
   // yesterday. A gap older than that means the streak is genuinely broken.
   let currentStreak = { days: 0, start: null, end: null };
   let i = days.length - 1;
-  if (i >= 0 && days[i].date === today && days[i].contributionCount === 0) {
+  const skippedEmptyToday =
+    i >= 0 && days[i].date === today && days[i].contributionCount === 0;
+  if (skippedEmptyToday) {
     i--; // today not contributed yet — don't count it, but don't break on it
   }
   if (i >= 0 && days[i].contributionCount > 0) {
-    const end = days[i].date;
+    // Keep `end` at TODAY when the only skipped day is an empty today: the
+    // streak is still ongoing (the day just isn't over yet). Pinning it to
+    // yesterday's date would make `formatStreakRange` drop the "Present" label
+    // AND shift `currentStreak.dateRange` at every midnight rollover, which
+    // `streakFingerprint` would read as a real change and fire a false banner.
+    const end = skippedEmptyToday ? today : days[i].date;
     let start = end;
     let count = 0;
     while (i >= 0 && days[i].contributionCount > 0) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -635,45 +635,6 @@
       0 0 9px rgba(255, 109, 5, 0.15);
     animation: repo-card-breathe 3s ease-in-out infinite;
   }
-
-  /* Breathing glow for the current-streak progress ring. Replaces the previous
-     static drop-shadow with a slow pulse so the ring reads as "alive". The
-     baseline `filter` survives when the animation is disabled (reduced motion),
-     so the ring keeps its resting halo instead of going flat. The `--peak`
-     variant burns hotter and is applied only when the current streak has
-     matched the all-time longest (a personal best). */
-  @keyframes streak-ring-pulse {
-    0%,
-    100% {
-      filter: drop-shadow(0 0 3px rgba(255, 109, 5, 0.4));
-    }
-    50% {
-      filter: drop-shadow(0 0 9px rgba(255, 109, 5, 0.85));
-    }
-  }
-  @keyframes streak-ring-pulse-peak {
-    0%,
-    100% {
-      filter: drop-shadow(0 0 5px rgba(255, 170, 42, 0.6));
-    }
-    50% {
-      filter: drop-shadow(0 0 14px rgba(255, 170, 42, 1));
-    }
-  }
-  .streak-ring-glow {
-    filter: drop-shadow(0 0 4px rgba(255, 109, 5, 0.4));
-  }
-  .streak-ring-glow--peak {
-    filter: drop-shadow(0 0 6px rgba(255, 170, 42, 0.65));
-  }
-  @media (prefers-reduced-motion: no-preference) {
-    .streak-ring-glow {
-      animation: streak-ring-pulse 2.6s ease-in-out infinite;
-    }
-    .streak-ring-glow--peak {
-      animation: streak-ring-pulse-peak 2.2s ease-in-out infinite;
-    }
-  }
 }
 
 /* One-shot light sweep across the Most Used Languages stacked bar when it

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -635,6 +635,45 @@
       0 0 9px rgba(255, 109, 5, 0.15);
     animation: repo-card-breathe 3s ease-in-out infinite;
   }
+
+  /* Breathing glow for the current-streak progress ring. Replaces the previous
+     static drop-shadow with a slow pulse so the ring reads as "alive". The
+     baseline `filter` survives when the animation is disabled (reduced motion),
+     so the ring keeps its resting halo instead of going flat. The `--peak`
+     variant burns hotter and is applied only when the current streak has
+     matched the all-time longest (a personal best). */
+  @keyframes streak-ring-pulse {
+    0%,
+    100% {
+      filter: drop-shadow(0 0 3px rgba(255, 109, 5, 0.4));
+    }
+    50% {
+      filter: drop-shadow(0 0 9px rgba(255, 109, 5, 0.85));
+    }
+  }
+  @keyframes streak-ring-pulse-peak {
+    0%,
+    100% {
+      filter: drop-shadow(0 0 5px rgba(255, 170, 42, 0.6));
+    }
+    50% {
+      filter: drop-shadow(0 0 14px rgba(255, 170, 42, 1));
+    }
+  }
+  .streak-ring-glow {
+    filter: drop-shadow(0 0 4px rgba(255, 109, 5, 0.4));
+  }
+  .streak-ring-glow--peak {
+    filter: drop-shadow(0 0 6px rgba(255, 170, 42, 0.65));
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .streak-ring-glow {
+      animation: streak-ring-pulse 2.6s ease-in-out infinite;
+    }
+    .streak-ring-glow--peak {
+      animation: streak-ring-pulse-peak 2.2s ease-in-out infinite;
+    }
+  }
 }
 
 /* One-shot light sweep across the Most Used Languages stacked bar when it

--- a/src/components/about/ExperienceBreakdownModal.jsx
+++ b/src/components/about/ExperienceBreakdownModal.jsx
@@ -409,6 +409,39 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
     if (open) setShowAllRepos(false);
   }, [open]);
 
+  // Scrollbar repaint on foreground return. The repo links open with
+  // `target="_blank"`, so tapping one (e.g. on mobile to open GitHub) leaves
+  // this tab backgrounded rather than navigating it away. Android Chrome — and
+  // bfcache restores generally — drop a *nested* scroll container's inherited
+  // `scrollbar-color` when the tab returns to the foreground, so the modal's
+  // orange thumb reverts to the default grey until a manual refresh. There's no
+  // CSS-only fix, so when the page is shown again we re-assert the colour
+  // explicitly on the scroll element, toggling through `auto` first (with a
+  // forced reflow between the two writes) so it's a genuine computed-value
+  // change the browser can't coalesce into a no-op.
+  useEffect(() => {
+    if (!open) return undefined;
+    const repaintScrollbar = () => {
+      const node = scrollRef.current;
+      if (!node) return;
+      node.style.scrollbarColor = "auto";
+      void node.offsetHeight; // flush so the writes aren't merged
+      node.style.scrollbarColor = "#ff6d05 #222";
+    };
+    const onPageShow = (e) => {
+      if (e.persisted) repaintScrollbar();
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") repaintScrollbar();
+    };
+    window.addEventListener("pageshow", onPageShow);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("pageshow", onPageShow);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [open]);
+
   // Body scroll lock — restore prior values on close so we don't clobber
   // settings that might be applied elsewhere. Also sets `data-modal-open`
   // on <body> so the floating home button (`.control-island`, z:120) can
@@ -630,7 +663,15 @@ export function ExperienceBreakdownModal({ open, onClose, data, triggerRef }) {
               // sizing trick as the panel above so the scroll region
               // matches the visible viewport on iOS.
               className="max-h-[88vh] overflow-y-auto overscroll-contain p-6 sm:p-8"
-              style={{ maxHeight: "88dvh" }}
+              // Set the scrollbar colour explicitly (not just inherited from
+              // `html`) so it's an own declaration on the scroller — paired
+              // with the foreground-return repaint effect above, this keeps the
+              // orange thumb from reverting to grey after an outbound link.
+              style={{
+                maxHeight: "88dvh",
+                scrollbarColor: "#ff6d05 #222",
+                scrollbarWidth: "thin",
+              }}
             >
             <header className="flex items-start justify-between gap-4 mb-6">
               <div>

--- a/src/components/about/LanguagesCard.jsx
+++ b/src/components/about/LanguagesCard.jsx
@@ -69,6 +69,16 @@ const metricRowVariants = {
   visible: { opacity: 1, x: 0, transition: { duration: 0.45, ease: "easeOut" } },
 };
 
+// Reduced-motion no-op: hidden === visible at the resting state with no tween,
+// so the card simply appears (no spring, slide, or staggered replay) for users
+// who've opted out of motion. Used in place of every variant set above when
+// `prefers-reduced-motion` is set — mirroring AnimatedTitle's reduced path so
+// the whole card honours the preference, not just the title.
+const noMotionVariants = {
+  hidden: { opacity: 1, x: 0, y: 0, scale: 1 },
+  visible: { opacity: 1, x: 0, y: 0, scale: 1 },
+};
+
 /* Per-character blur-fade-in title — the exact treatment the GitHub Stats card
    uses, in the same vivid orange (#ff6d05) so the two headlines read as one
    system. Reduced motion renders a plain heading; the per-char spans are
@@ -135,6 +145,17 @@ export default function LanguagesCard({ data, isLive = false }) {
     amount: 0.3,
     margin: "-50px",
   });
+
+  // Honour reduced motion across the whole entrance: swap every animated variant
+  // set for the resting no-op so nothing springs, slides, or re-plays on
+  // re-entry for users who opted out (AnimatedTitle already takes its own
+  // reduced path). The count-ups handle reduced motion separately.
+  const cardV = prefersReducedMotion ? noMotionVariants : cardVariants;
+  const childV = prefersReducedMotion ? noMotionVariants : childVariants;
+  const listContainerV = prefersReducedMotion
+    ? noMotionVariants
+    : metricContainerVariants;
+  const rowV = prefersReducedMotion ? noMotionVariants : metricRowVariants;
 
   const languages = Array.isArray(data) ? data : [];
   // Denominator for the stacked bar. The normalized list sums to ~100, but
@@ -359,7 +380,7 @@ export default function LanguagesCard({ data, isLive = false }) {
       // `isInView` would replay as a glitch), but REVERSIBLE: it flips false
       // after a sustained exit so the whole entrance REPLAYS on every true
       // re-entry instead of firing once. Count-ups still replay via `playToken`.
-      variants={cardVariants}
+      variants={cardV}
       initial="hidden"
       animate={settledInView ? "visible" : "hidden"}
       // Border + glow parity with the "Years in the craft" card: the outer
@@ -377,7 +398,7 @@ export default function LanguagesCard({ data, isLive = false }) {
       />
 
       {/* Header — title + an analytics-style meta line. */}
-      <motion.div variants={childVariants} className="mb-5">
+      <motion.div variants={childV} className="mb-5">
         {/* Title — per-character blur-in in vivid orange (#ff6d05), the exact
             treatment + hue the "… GitHub Stats" card uses, so the side-by-side
             pair share one headline animation and colour. */}
@@ -403,7 +424,7 @@ export default function LanguagesCard({ data, isLive = false }) {
           sheen overlay; per-segment right borders draw crisp dividers
           between colours without changing layout width (border-box). */}
       <motion.div
-        variants={childVariants}
+        variants={childV}
         aria-hidden="true"
         className="relative w-full h-2 md:h-3 rounded-full overflow-hidden flex mb-5 bg-gray-700/30"
       >
@@ -444,7 +465,7 @@ export default function LanguagesCard({ data, isLive = false }) {
           proportion bar above still reflects every language, so it stays a
           complete overview regardless of how many rows are listed. */}
       <motion.ul
-        variants={metricContainerVariants}
+        variants={listContainerV}
         className="grid grid-cols-1 xl:grid-cols-2 gap-y-3 gap-x-6 pt-2 text-sm md:text-base xl:text-sm"
       >
         {languages.slice(0, 10).map((lang, idx) => (
@@ -454,7 +475,7 @@ export default function LanguagesCard({ data, isLive = false }) {
             rank={idx + 1}
             isPrimary={idx === 0}
             hiddenUntilXl={idx >= 5}
-            variants={metricRowVariants}
+            variants={rowV}
             playToken={playToken}
             prefersReducedMotion={prefersReducedMotion}
             active={activeIndex === idx}
@@ -638,8 +659,15 @@ function AnimatedLangLabel({
           onActivate();
           onRepoFocus?.(e.currentTarget);
         }}
-        onBlur={() => {
+        onBlur={(e) => {
+          // Clear the spotlight whenever focus leaves the row (mirrors the
+          // pointer path's onMouseLeave). But only schedule the popover CLOSE
+          // when focus isn't moving INTO the popover — Tab from the row lands on
+          // a repo link in the body-portaled panel (matched by its data attr,
+          // not DOM ancestry), and closing then would dismiss those links before
+          // they're reachable. The popover closes itself once focus leaves it.
           onDeactivate();
+          if (e.relatedTarget?.closest?.("[data-lang-popover]")) return;
           onRepoClose?.();
         }}
         onClick={(e) => onRepoTap?.(e.currentTarget)}
@@ -761,6 +789,23 @@ function LanguageRepoPopover({
       aria-label={`Repositories using ${lang.language}`}
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
+      // Keyboard equivalents of pointer enter/leave (React onFocus/onBlur bubble
+      // from the repo links inside). Focus entering the panel cancels any pending
+      // close; focus leaving it closes — UNLESS it lands back on the panel
+      // (tabbing between repo links) or on a language row (the trigger, or
+      // another row that opens its own), so the links stay reachable by keyboard.
+      onFocus={onPointerEnter}
+      onBlur={(e) => {
+        const next = e.relatedTarget;
+        if (
+          next &&
+          (next.closest?.("[data-lang-popover]") ||
+            next.closest?.("[data-lang-row]"))
+        ) {
+          return;
+        }
+        onPointerLeave?.();
+      }}
       data-lang-popover=""
       className="custom-bg-abt rounded-xl flex flex-col"
       style={{

--- a/src/components/about/LanguagesCard.jsx
+++ b/src/components/about/LanguagesCard.jsx
@@ -24,6 +24,105 @@ const COUNT_UP_DURATION = 2; // seconds
 // How long the change banner lingers once the section scrolls into view.
 const BANNER_AUTO_HIDE_MS = 4500;
 
+// ----- Card-level entrance choreography — mirrors the GitHub Stats card
+// (StatsCard.jsx) 1:1 so the side-by-side pair animate IN identically: the card
+// springs up (opacity/y/scale) and its sections cascade via `staggerChildren`,
+// with the title typing in per character. Driven off `settledInView`, so the
+// whole entrance REPLAYS on every true viewport re-entry.
+const cardVariants = {
+  hidden: { opacity: 0, y: 56, scale: 0.97 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: {
+      type: "spring",
+      stiffness: 70,
+      damping: 18,
+      staggerChildren: 0.07,
+      delayChildren: 0.15,
+    },
+  },
+};
+
+const childVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { type: "spring", stiffness: 120, damping: 20 },
+  },
+};
+
+// Row choreography — IDENTICAL to the GitHub Stats card's metric rows
+// (Total Stars Earned, Total Commits, …): the list is a stagger container and
+// each language row slides in from the left (x: -16 → 0) one after another.
+// Because the list is itself a stagger child of the card, this cascade plays
+// after the header + bar, and replays on every viewport entry.
+const metricContainerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.06 } },
+};
+
+const metricRowVariants = {
+  hidden: { opacity: 0, x: -16 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.45, ease: "easeOut" } },
+};
+
+/* Per-character blur-fade-in title — the exact treatment the GitHub Stats card
+   uses, in the same vivid orange (#ff6d05) so the two headlines read as one
+   system. Reduced motion renders a plain heading; the per-char spans are
+   aria-hidden with an aria-label so the accessible name stays clean. */
+function AnimatedTitle({ text, play }) {
+  const prefersReducedMotion = useReducedMotion();
+  const className =
+    "text-xl md:text-2xl text-left font-semibold mb-1 break-words leading-tight";
+
+  if (prefersReducedMotion) {
+    return (
+      <h2 className={className} style={{ color: "#ff6d05", textShadow: "none" }}>
+        {text}
+      </h2>
+    );
+  }
+
+  const chars = Array.from(text);
+  const container = {
+    hidden: {},
+    visible: { transition: { staggerChildren: 0.025, delayChildren: 0.2 } },
+  };
+  const charVariant = {
+    hidden: { opacity: 0, filter: "blur(6px)", y: 8 },
+    visible: {
+      opacity: 1,
+      filter: "blur(0px)",
+      y: 0,
+      transition: { duration: 0.35, ease: "easeOut" },
+    },
+  };
+  return (
+    <motion.h2
+      variants={container}
+      initial="hidden"
+      animate={play ? "visible" : "hidden"}
+      className={className}
+      style={{ color: "#ff6d05", textShadow: "none" }}
+      aria-label={text}
+    >
+      {chars.map((c, i) => (
+        <motion.span
+          key={i}
+          variants={charVariant}
+          style={{ display: "inline-block" }}
+          aria-hidden="true"
+        >
+          {c === " " ? " " : c}
+        </motion.span>
+      ))}
+    </motion.h2>
+  );
+}
+
 export default function LanguagesCard({ data, isLive = false }) {
   const cardRef = useRef(null);
   const prefersReducedMotion = useReducedMotion();
@@ -32,7 +131,7 @@ export default function LanguagesCard({ data, isLive = false }) {
   // immune to the rapid in/out IntersectionObserver flicker that made the
   // old `useInView`-driven count-up restart mid-scroll (issue #16/17 bug
   // class). Children animate on `playToken`, not raw visibility.
-  const { isInView, playToken } = useViewportCountTrigger(cardRef, {
+  const { isInView, playToken, settledInView } = useViewportCountTrigger(cardRef, {
     amount: 0.3,
     margin: "-50px",
   });
@@ -253,16 +352,16 @@ export default function LanguagesCard({ data, isLive = false }) {
   return (
     <motion.div
       ref={cardRef}
-      initial={{ opacity: 0, y: 40 }}
-      // Drive the fade-in off the latched, flicker-immune `playToken` (>0 once
-      // a true entry happens) instead of raw `isInView`. The parent ItemLayout
-      // animates scale 0 → 1 on entry, which wobbles this card's observer rect
-      // and made raw `isInView` toggle true/false/true — replaying the fade and
-      // looking like a glitch. `playToken > 0` flips once and stays, so the
-      // entrance plays a single time; the count-ups still replay via the
-      // `playToken` value passed to the bar/label children.
-      animate={playToken > 0 ? { opacity: 1, y: 0 } : {}}
-      transition={{ duration: 1, ease: "easeOut" }}
+      // Entrance choreography is the GitHub Stats card's, 1:1 (`cardVariants` +
+      // `childVariants` + the per-char title). Driven off `settledInView` —
+      // debounced and flicker-immune like `playToken` (the parent ItemLayout's
+      // scale 0 → 1 entry wobbles this card's observer rect, which raw
+      // `isInView` would replay as a glitch), but REVERSIBLE: it flips false
+      // after a sustained exit so the whole entrance REPLAYS on every true
+      // re-entry instead of firing once. Count-ups still replay via `playToken`.
+      variants={cardVariants}
+      initial="hidden"
+      animate={settledInView ? "visible" : "hidden"}
       // Border + glow parity with the "Years in the craft" card: the outer
       // `custom-bg-abt` amber border comes from the `!p-0` ItemLayout
       // wrapper (index.jsx), and this inner `repo-card-breathe rounded-lg`
@@ -278,16 +377,11 @@ export default function LanguagesCard({ data, isLive = false }) {
       />
 
       {/* Header — title + an analytics-style meta line. */}
-      <div className="mb-5">
-        {/* Title — vivid orange (#ff6d05), matching the "… GitHub Stats" card
-            title so the side-by-side pair share one headline hue. Flat,
-            semibold, no neon glow. */}
-        <h2
-          className="text-xl md:text-2xl text-left font-semibold mb-1"
-          style={{ color: "#ff6d05", textShadow: "none" }}
-        >
-          Most Used Languages
-        </h2>
+      <motion.div variants={childVariants} className="mb-5">
+        {/* Title — per-character blur-in in vivid orange (#ff6d05), the exact
+            treatment + hue the "… GitHub Stats" card uses, so the side-by-side
+            pair share one headline animation and colour. */}
+        <AnimatedTitle text="Most Used Languages" play={settledInView} />
         {/* Meta line — frames the card as a live data widget. Count is
             pluralised; the "· live from GitHub" suffix is shown only when
             `isLive` (the displayed languages came from a genuine live
@@ -302,13 +396,14 @@ export default function LanguagesCard({ data, isLive = false }) {
           {languages.length} {languages.length === 1 ? "language" : "languages"}
           {isLive && " · live from GitHub"}
         </p>
-      </div>
+      </motion.div>
 
       {/* Combined horizontal stacked bar — decorative; the list below
           carries the same data accessibly. `relative` anchors the one-shot
           sheen overlay; per-segment right borders draw crisp dividers
           between colours without changing layout width (border-box). */}
-      <div
+      <motion.div
+        variants={childVariants}
         aria-hidden="true"
         className="relative w-full h-2 md:h-3 rounded-full overflow-hidden flex mb-5 bg-gray-700/30"
       >
@@ -331,7 +426,7 @@ export default function LanguagesCard({ data, isLive = false }) {
         {playToken > 0 && !prefersReducedMotion && (
           <span key={playToken} className="lang-bar-sheen" aria-hidden="true" />
         )}
-      </div>
+      </motion.div>
 
       {/* Language list — a single column on mobile AND tablet (incl. iPad-
           landscape at `lg`/1024, where this card is already half-width beside
@@ -348,7 +443,10 @@ export default function LanguagesCard({ data, isLive = false }) {
           all 10 — matching the wider canvas to a fuller list. The decorative
           proportion bar above still reflects every language, so it stays a
           complete overview regardless of how many rows are listed. */}
-      <ul className="grid grid-cols-1 xl:grid-cols-2 gap-y-3 gap-x-6 pt-2 text-sm md:text-base xl:text-sm">
+      <motion.ul
+        variants={metricContainerVariants}
+        className="grid grid-cols-1 xl:grid-cols-2 gap-y-3 gap-x-6 pt-2 text-sm md:text-base xl:text-sm"
+      >
         {languages.slice(0, 10).map((lang, idx) => (
           <AnimatedLangLabel
             key={lang.language ?? idx}
@@ -356,6 +454,7 @@ export default function LanguagesCard({ data, isLive = false }) {
             rank={idx + 1}
             isPrimary={idx === 0}
             hiddenUntilXl={idx >= 5}
+            variants={metricRowVariants}
             playToken={playToken}
             prefersReducedMotion={prefersReducedMotion}
             active={activeIndex === idx}
@@ -368,7 +467,7 @@ export default function LanguagesCard({ data, isLive = false }) {
             onRepoClose={scheduleClose}
           />
         ))}
-      </ul>
+      </motion.ul>
 
       {/* Repo-breakdown popover — portaled to <body> so it escapes the card's
           `overflow-hidden`. Rendered only while a row with a known breakdown
@@ -467,6 +566,7 @@ function AnimatedLangLabel({
   rank,
   isPrimary,
   hiddenUntilXl = false,
+  variants,
   playToken,
   prefersReducedMotion,
   active,
@@ -504,44 +604,54 @@ function AnimatedLangLabel({
   }, [playToken, target, prefersReducedMotion]);
 
   return (
-    <li
-      tabIndex={0}
-      data-lang-row=""
-      // The whole row is the popover trigger, so the name OR the percentage
-      // activates it; the same handlers still drive the bar spotlight.
-      // `currentTarget` (the <li>) is the positioning anchor. Open/close is
-      // mode-gated in the parent: hover/leave act only with a fine pointer,
-      // focus opens only when the keyboard drove it, and tap toggles only on
-      // touch — so touch → tap, keyboard → hover/focus, mouse → hover.
-      onMouseEnter={(e) => {
-        onActivate();
-        onRepoEnter?.(e.currentTarget);
-      }}
-      onMouseLeave={() => {
-        onDeactivate();
-        onRepoClose?.();
-      }}
-      onFocus={(e) => {
-        onActivate();
-        onRepoFocus?.(e.currentTarget);
-      }}
-      onBlur={() => {
-        onDeactivate();
-        onRepoClose?.();
-      }}
-      onClick={(e) => onRepoTap?.(e.currentTarget)}
-      aria-haspopup={hasRepos ? "true" : undefined}
-      // `hiddenUntilXl` rows (the 6th–10th languages) are display:none below
-      // `xl` so the single-column view lists only the top 5; at `xl`+ they
-      // become flex items again and fill the second column.
-      className={`group ${hiddenUntilXl ? "hidden xl:flex" : "flex"} items-center gap-2 min-w-0 rounded-md outline-none transition-[opacity,transform] duration-200 ${
-        hasRepos ? "cursor-pointer" : ""
-      }`}
-      style={{
-        opacity: dimmed ? 0.4 : 1,
-        transform: active ? "translateX(2px)" : "none",
-      }}
+    // Two layers, deliberately separated so two animation systems don't fight
+    // over the same CSS properties:
+    //   • <motion.li> owns the ENTRANCE — framer animates opacity + x (-16 → 0)
+    //     via `variants` (the metric-row slide-in, staggered by the parent ul).
+    //     It's the grid cell, so `hiddenUntilXl` toggles its display.
+    //   • the inner <div> owns the INTERACTION — the hover/focus spotlight's
+    //     React-controlled `opacity` (dim) + `transform` (nudge). Keeping these
+    //     off the motion.li avoids clobbering framer's entrance transform/opacity
+    //     (and vice-versa); the two opacities simply compose.
+    <motion.li
+      variants={variants}
+      className={hiddenUntilXl ? "hidden xl:block" : "block"}
     >
+      <div
+        tabIndex={0}
+        data-lang-row=""
+        // The whole row is the popover trigger, so the name OR the percentage
+        // activates it; the same handlers still drive the bar spotlight.
+        // `currentTarget` (this div) is the positioning anchor. Open/close is
+        // mode-gated in the parent: hover/leave act only with a fine pointer,
+        // focus opens only when the keyboard drove it, and tap toggles only on
+        // touch — so touch → tap, keyboard → hover/focus, mouse → hover.
+        onMouseEnter={(e) => {
+          onActivate();
+          onRepoEnter?.(e.currentTarget);
+        }}
+        onMouseLeave={() => {
+          onDeactivate();
+          onRepoClose?.();
+        }}
+        onFocus={(e) => {
+          onActivate();
+          onRepoFocus?.(e.currentTarget);
+        }}
+        onBlur={() => {
+          onDeactivate();
+          onRepoClose?.();
+        }}
+        onClick={(e) => onRepoTap?.(e.currentTarget)}
+        aria-haspopup={hasRepos ? "true" : undefined}
+        className={`group flex items-center gap-2 min-w-0 rounded-md outline-none transition-[opacity,transform] duration-200 ${
+          hasRepos ? "cursor-pointer" : ""
+        }`}
+        style={{
+          opacity: dimmed ? 0.4 : 1,
+          transform: active ? "translateX(2px)" : "none",
+        }}
+      >
       {/* Rank index — monospaced, dim, fixed-width so the dots/names align
           into a clean column. Reads like an analytics leaderboard. */}
       {/* Rank index — hidden at `xl`+, where the list splits into two tighter
@@ -598,7 +708,8 @@ function AnimatedLangLabel({
       >
         <span ref={numRef}>{prefersReducedMotion ? target.toFixed(2) : "0.00"}</span>%
       </span>
-    </li>
+      </div>
+    </motion.li>
   );
 }
 

--- a/src/components/about/RepoStatsCard.jsx
+++ b/src/components/about/RepoStatsCard.jsx
@@ -421,20 +421,19 @@ export default function ReadmeStatsCard({ data, isUpdated, diffMessage }) {
   const ref = useRef(null);
   // Two visibility signals, intentionally separated:
   //   - `playToken` (latched + hysteresis-debounced, monotonic) drives the
-  //     numeric count-ups AND, via `hasEntered`, the card's outer fade-in
-  //     variants and the AnimatedTitle's `play`. The parent ItemLayout
-  //     animates scale 0 → 1 on entry, which wobbles this card's observer
-  //     rect; raw `isInView` then toggled true/false/true and replayed the
-  //     entrance + per-char title blur — the visible glitch. `playToken > 0`
-  //     flips once on a real entry and never reverts, so the entrance plays a
-  //     single clean time while the count-ups still replay on re-entry (they
-  //     key off the playToken value). `amount: 0.3` fires at ~30% crossing.
+  //     numeric count-ups, which key off its value and replay on re-entry by
+  //     themselves. The parent ItemLayout animates scale 0 → 1 on entry, which
+  //     wobbles this card's observer rect; `playToken`/`settledInView` are both
+  //     debounced so that wobble can't replay anything spuriously.
+  //   - `settledInView` (debounced like playToken, but reversible) drives the
+  //     card's outer fade-in variants and the AnimatedTitle's `play`, so the
+  //     entrance + per-char title blur REPLAY on every true re-entry instead of
+  //     firing once on first load. `amount: 0.3` fires at ~30% crossing.
   //   - `isInView` (raw observer) is kept only for the diff-message banner
   //     gate, which is harmless flickering off-screen (no message shown).
-  const { isInView, playToken } = useViewportCountTrigger(ref, {
+  const { isInView, playToken, settledInView } = useViewportCountTrigger(ref, {
     amount: 0.3,
   });
-  const hasEntered = playToken > 0;
   // Mirrors the CSS `prefers-reduced-motion` override in globals.css so the
   // decorative pulse on the language-color dot also holds still for users
   // who've opted out of motion.
@@ -471,7 +470,7 @@ export default function ReadmeStatsCard({ data, isUpdated, diffMessage }) {
       ref={ref}
       variants={cardVariants}
       initial="hidden"
-      animate={hasEntered ? "visible" : "hidden"}
+      animate={settledInView ? "visible" : "hidden"}
       className="repo-card-breathe w-full p-6 relative overflow-hidden rounded-lg"
     >
       <UpdateBanner
@@ -487,7 +486,7 @@ export default function ReadmeStatsCard({ data, isUpdated, diffMessage }) {
             className="w-5 h-5 flex-shrink-0"
             style={{ color: "#ffaa2a" }}
           />
-          <AnimatedTitle text={name} play={hasEntered} />
+          <AnimatedTitle text={name} play={settledInView} />
         </div>
         <span
           // Eyebrow microlabel — same role as "CAREER SNAPSHOT" on the

--- a/src/components/about/StatsCard.jsx
+++ b/src/components/about/StatsCard.jsx
@@ -308,15 +308,13 @@ function RankArc({ level, percentile, playToken, prefersReducedMotion }) {
 /* ---------------------------------- CARD ---------------------------------- */
 export default function GitHubStatsCard({ data, userName = "GitHub User", isUpdated, diffMessage = null, isLive = false }) {
     const cardRef = useRef(null);
-    // `playToken` (latched, hysteresis-debounced, monotonic) drives BOTH the
-    // count-ups AND the entrance fade/title play — the parent ItemLayout's
-    // scale 0 → 1 entry wobbles this card's observer rect, so raw `isInView`
-    // toggled true/false/true and replayed the entrance (the visible glitch).
-    // `playToken > 0` flips once on a real entry and never reverts, so the
-    // entrance plays a single clean time. `isInView` is kept only for the
-    // banner gate, which is fine flickering off-screen (no message shown).
-    const { isInView, playToken } = useViewportCountTrigger(cardRef, { amount: 0.3, margin: "-50px" });
-    const hasEntered = playToken > 0;
+    // `playToken` (latched, hysteresis-debounced, monotonic) drives the
+    // count-ups/arc, which key off its value and replay each entry on their
+    // own. `settledInView` (debounced + reversible, so flicker-immune like
+    // playToken but able to revert) drives the entrance fade + title play so
+    // they REPLAY on every true viewport re-entry rather than once on first
+    // load. `isInView` is kept only for the banner gate.
+    const { isInView, playToken, settledInView } = useViewportCountTrigger(cardRef, { amount: 0.3, margin: "-50px" });
     const prefersReducedMotion = useReducedMotion();
 
     // Banner message: prefer the specific per-stat diff; fall back to a generic
@@ -352,7 +350,7 @@ export default function GitHubStatsCard({ data, userName = "GitHub User", isUpda
             ref={cardRef}
             variants={cardVariants}
             initial="hidden"
-            animate={hasEntered ? "visible" : "hidden"}
+            animate={settledInView ? "visible" : "hidden"}
             className="repo-card-breathe w-full p-6 relative overflow-hidden rounded-lg h-full"
         >
             <UpdateBanner
@@ -372,7 +370,7 @@ export default function GitHubStatsCard({ data, userName = "GitHub User", isUpda
             <motion.div variants={childVariants} className="mb-2">
                 <div className="flex items-center gap-2 min-w-0">
                     <Activity className="w-5 h-5 flex-shrink-0" style={{ color: AMBER }} />
-                    <AnimatedTitle text={`${userName}'s GitHub Stats`} play={hasEntered} />
+                    <AnimatedTitle text={`${userName}'s GitHub Stats`} play={settledInView} />
                 </div>
                 {isLive && (
                     <div className="flex items-center gap-2 mt-1.5">

--- a/src/components/about/StreakStatsCard.jsx
+++ b/src/components/about/StreakStatsCard.jsx
@@ -61,6 +61,11 @@ function StreakNumber({
       node.textContent = "0";
       return undefined;
     }
+    // Reset to 0 SYNCHRONOUSLY before scheduling the tween. animateToTarget
+    // paints its first value on the next rAF tick, so without this the node
+    // would show its previous final value (e.g. the last streak count) for one
+    // frame on a re-entry or data change before dropping to 0 — a visible flash.
+    node.textContent = "0";
     const cancel = animateToTarget({
       from: 0,
       to: safe,

--- a/src/components/about/StreakStatsCard.jsx
+++ b/src/components/about/StreakStatsCard.jsx
@@ -47,7 +47,14 @@ function StreakNumber({
   srLabel,
 }) {
   const ref = useRef(null);
-  const safe = Number(target) || 0;
+  // Coerce to a FINITE number. `Number(target) || 0` would catch NaN (falsy)
+  // but let `Infinity`/`-Infinity` through (both truthy) — the reduced-motion
+  // path writes `String(safe)` and would render the literal "Infinity", and the
+  // sr-only label / initial paint would expose it too. `Number.isFinite` mirrors
+  // the guard `animateToTarget` already applies to `to`, so the reduced-motion
+  // and animated paths land on the same valid target.
+  const n = Number(target);
+  const safe = Number.isFinite(n) ? n : 0;
 
   useEffect(() => {
     const node = ref.current;

--- a/src/components/about/StreakStatsCard.jsx
+++ b/src/components/about/StreakStatsCard.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
-import { Flame, GitCommitVertical } from "lucide-react";
+import { GitCommitVertical } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { UpdateBanner } from "./UpdateBanner";
@@ -82,12 +82,36 @@ function StreakNumber({
   );
 }
 
+/* ----------------------- STAGGERED ENTRANCE VARIANTS -----------------------
+   The card reveals its three sections in sequence on every viewport entry —
+   Total Contributions, then the Current Streak ring, then Longest Streak — a
+   left-to-right cascade rather than everything popping at once. The row is the
+   stagger container; each column (and the dividers between them) is an item, so
+   they fade+rise in DOM order. Reduced motion swaps to the "still" item set
+   (no transform/opacity tween) while keeping the same structure. */
+const STAGGER_CONTAINER = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.13, delayChildren: 0.1 } },
+};
+const STAGGER_ITEM = {
+  hidden: { opacity: 0, y: 22 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" } },
+};
+const STAGGER_ITEM_STILL = {
+  hidden: { opacity: 1, y: 0 },
+  visible: { opacity: 1, y: 0 },
+};
+
 /* ------------------------------- STAT BLOCK -------------------------------
    Total Contributions / Longest Streak: a count-up number, a fire-amber
-   label, and a static (never animated) muted-gold date range. */
-function StatBlock({ label, value, dateRange, playToken, prefersReducedMotion }) {
+   label, and a static (never animated) muted-gold date range. Rendered as a
+   stagger item so it slides into the cascade. */
+function StatBlock({ label, value, dateRange, playToken, prefersReducedMotion, variants }) {
   return (
-    <div className="flex flex-col items-center justify-center flex-1 text-center min-w-0">
+    <motion.div
+      variants={variants}
+      className="flex flex-col items-center justify-center flex-1 text-center min-w-0"
+    >
       <StreakNumber
         target={Number(value) || 0}
         playToken={playToken}
@@ -107,15 +131,17 @@ function StatBlock({ label, value, dateRange, playToken, prefersReducedMotion })
       >
         {dateRange}
       </span>
-    </div>
+    </motion.div>
   );
 }
 
 // Vertical gradient divider — a faded amber line that dissolves at both ends,
 // replacing the previous flat white rule. Hidden on the stacked mobile layout.
-function Divider() {
+// A stagger item so it fades in between its two neighbouring columns.
+function Divider({ variants }) {
   return (
-    <div
+    <motion.div
+      variants={variants}
       aria-hidden="true"
       className="hidden sm:block w-px self-stretch my-2 mx-1 shrink-0"
       style={{
@@ -132,12 +158,16 @@ export default function StreakStatsCard({ data }) {
   // count-ups + ring sweep on each TRUE re-entry (never loops while the card
   // stays visible, and absorbs the IntersectionObserver flicker that the raw
   // observer would emit during the parent ItemLayout's scale entrance);
-  // `isInView` gates the banner's visual. `hasEntered` drives the one-shot
-  // entrance so that flicker can't replay the fade.
-  const { isInView, playToken } = useViewportCountTrigger(cardRef, {
+  // `settledInView` (debounced + reversible) drives the card's fade/slide
+  // entrance so it replays on every re-entry; `isInView` gates the banner.
+  const { isInView, playToken, settledInView } = useViewportCountTrigger(cardRef, {
     amount: 0.3,
     margin: "-50px",
   });
+  // `hasEntered` (monotonic) still gates the ring/count-up internals, which
+  // key off `playToken` and replay on their own. `settledInView` (debounced,
+  // reversible) drives the card's fade/slide entrance so it REPLAYS on every
+  // true viewport re-entry instead of firing once on first load.
   const hasEntered = playToken > 0;
   const prefersReducedMotion = useReducedMotion();
 
@@ -173,10 +203,6 @@ export default function StreakStatsCard({ data }) {
   const fraction =
     longest > 0 ? Math.min(current / longest, 1) : current > 0 ? 1 : 0;
   const filledOffset = RING_CIRCUMFERENCE * (1 - fraction);
-  // Personal best: the current run has caught (or matched) the all-time
-  // longest. This is the card's hero moment — it lights the ring hotter and
-  // surfaces the "Personal best" badge below the current-streak label.
-  const isPeak = current > 0 && current >= longest;
   const ringSrLabel =
     longest > 0
       ? `${current} day${current === 1 ? "" : "s"}, ${Math.round(
@@ -184,20 +210,20 @@ export default function StreakStatsCard({ data }) {
         )} percent of your longest streak`
       : `${current} day${current === 1 ? "" : "s"}`;
 
+  // Stagger item variant set — motion when allowed, still under reduced motion.
+  const itemVariants = prefersReducedMotion ? STAGGER_ITEM_STILL : STAGGER_ITEM;
+
   return (
     // `repo-card-breathe rounded-lg` matches the sibling cards' inner chrome
     // (the breathing orange halo on a rounded perimeter inside the ItemLayout's
-    // amber `custom-bg-abt` border). The original opacity/y entrance is
-    // preserved but driven off `hasEntered` so it plays once cleanly.
+    // amber `custom-bg-abt` border). The card itself just fades in on
+    // `settledInView`; the three stat sections inside cascade in sequence (see
+    // the stagger container below), and both replay on every viewport re-entry.
     <motion.div
       ref={cardRef}
-      initial={{ opacity: 0, y: prefersReducedMotion ? 0 : 30 }}
-      animate={
-        hasEntered
-          ? { opacity: 1, y: 0 }
-          : { opacity: 0, y: prefersReducedMotion ? 0 : 30 }
-      }
-      transition={{ duration: 0.6, ease: "easeOut" }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: settledInView ? 1 : 0 }}
+      transition={{ duration: prefersReducedMotion ? 0 : 0.4, ease: "easeOut" }}
       className="repo-card-breathe rounded-lg w-full h-full relative overflow-hidden p-5 sm:p-6 flex flex-col justify-center"
     >
       <UpdateBanner
@@ -216,7 +242,14 @@ export default function StreakStatsCard({ data }) {
         Contribution streaks
       </p>
 
-      <div className="flex flex-col sm:flex-row items-stretch justify-between gap-5 sm:gap-2">
+      {/* Stagger container — reveals Total Contributions → Current Streak →
+          Longest Streak in a left-to-right cascade on each viewport entry. */}
+      <motion.div
+        variants={STAGGER_CONTAINER}
+        initial="hidden"
+        animate={settledInView ? "visible" : "hidden"}
+        className="flex flex-col sm:flex-row items-stretch justify-between gap-5 sm:gap-2"
+      >
         {/* Total Contributions */}
         <StatBlock
           label="Total Contributions"
@@ -224,13 +257,17 @@ export default function StreakStatsCard({ data }) {
           dateRange={totalContributions?.dateRange}
           playToken={playToken}
           prefersReducedMotion={prefersReducedMotion}
+          variants={itemVariants}
         />
 
-        <Divider />
+        <Divider variants={itemVariants} />
 
         {/* Current Streak — count-up centred in a progress ring whose fill
             shows the current streak as a share of the longest. */}
-        <div className="flex flex-col items-center justify-center flex-1 text-center min-w-0">
+        <motion.div
+          variants={itemVariants}
+          className="flex flex-col items-center justify-center flex-1 text-center min-w-0"
+        >
           <div className="relative w-20 h-20 sm:w-24 sm:h-24 lg:w-28 lg:h-28 flex items-center justify-center mb-2">
             <svg
               className="absolute w-full h-full"
@@ -248,12 +285,10 @@ export default function StreakStatsCard({ data }) {
               />
               {/* `key={playToken}` remounts the arc on each true entry so the
                   sweep replays; pre-entry (playToken 0 → hasEntered false) it
-                  holds empty. Reduced motion snaps to the filled offset. */}
+                  holds empty. Reduced motion snaps to the filled offset. No
+                  drop-shadow glow — the ring is a flat stroke. */}
               <motion.circle
                 key={playToken}
-                className={
-                  isPeak ? "streak-ring-glow--peak" : "streak-ring-glow"
-                }
                 cx="60"
                 cy="60"
                 r={RING_RADIUS}
@@ -326,32 +361,9 @@ export default function StreakStatsCard({ data }) {
           >
             {currentStreak?.dateRange}
           </span>
-          {/* Peak badge — only when the current run has matched the all-time
-              best. Subtle gold pill that celebrates the moment without
-              competing with the headline numbers. */}
-          {isPeak && (
-            <motion.span
-              initial={{ opacity: 0, scale: 0.85 }}
-              animate={
-                hasEntered
-                  ? { opacity: 1, scale: 1 }
-                  : { opacity: 0, scale: 0.85 }
-              }
-              transition={{ duration: 0.4, ease: "easeOut", delay: 0.6 }}
-              className="mt-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em]"
-              style={{
-                color: AMBER,
-                background: "rgba(255,170,42,0.10)",
-                border: "1px solid rgba(255,170,42,0.30)",
-              }}
-            >
-              <Flame size={9} fill={AMBER} style={{ color: AMBER }} aria-hidden="true" />
-              Personal best
-            </motion.span>
-          )}
-        </div>
+        </motion.div>
 
-        <Divider />
+        <Divider variants={itemVariants} />
 
         {/* Longest Streak */}
         <StatBlock
@@ -360,8 +372,9 @@ export default function StreakStatsCard({ data }) {
           dateRange={longestStreak?.dateRange}
           playToken={playToken}
           prefersReducedMotion={prefersReducedMotion}
+          variants={itemVariants}
         />
-      </div>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/components/about/StreakStatsCard.jsx
+++ b/src/components/about/StreakStatsCard.jsx
@@ -1,150 +1,367 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
-import { Flame } from "lucide-react";
+import { motion, useReducedMotion } from "framer-motion";
+import { Flame, GitCommitVertical } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { UpdateBanner } from "./UpdateBanner";
+import { useViewportCountTrigger } from "@/hooks/useViewportCountTrigger";
+import { useStreakUpdateSignal } from "@/hooks/useStreakUpdateSignal";
+import { animateToTarget, fastStartSlowFinish } from "@/utils/animationCurves";
 
-export default function StreakStatsCard({ data, isUpdated }) {
-    const cardRef = useRef(null);
-    const isInView = useInView(cardRef, { once: false, margin: "-50px" });
+// ---------------------------------------------------------------------------
+// Palette — exact parity with the rest of the About design system:
+//   ORANGE  #ff6d05      → all numbers + the ring fill (matches the GitHub
+//                          Stats card numbers/title and rank arc)
+//   text-fire-amber      → block labels (matches the Architect paragraph and
+//                          the other cards' stat labels)
+//   AMBER   #ffaa2a      → flame icon + eyebrow microlabel
+//   DATE_TONE #d4af7a    → muted gold for the date ranges — a softer variant
+//                          of the label tone so the hierarchy reads cleanly
+//   RING_TRACK           → faded #ff6d05 ghost of the fill (GitHub Stats arc)
+// ---------------------------------------------------------------------------
+const ORANGE = "#ff6d05";
+const AMBER = "#ffaa2a";
+const DATE_TONE = "#d4af7a";
+const RING_TRACK = "rgba(255,109,5,0.12)";
 
-    const { totalContributions, currentStreak, longestStreak } = data || {};
+const COUNT_UP_MS = 2000; // shared window so all three values land together
+const BANNER_VISIBLE_MS = 4500;
+const RING_RADIUS = 55;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
-    return (
-        <motion.div
-            ref={cardRef}
-            initial={{ opacity: 0, y: 30 }}
-            animate={isInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            className="w-full px-4 py-6 relative overflow-hidden"
-        >
-            <UpdateBanner
-                message={isUpdated ? "This streak data has been updated" : null}
-                visible={isInView}
-                srPrefix="Streaks update: "
-            />
-            <div className="flex flex-col sm:flex-row items-center md:justify-between justify-center sm:gap-2 gap-4">
-                {/* Total Contributions */}
-                <AnimatedStatBlock
-                    title="Total Contributions"
-                    value={totalContributions?.value}
-                    dateRange={totalContributions?.dateRange}
-                    isInView={isInView}
-                    delay={0}
-                />
+/* ----------------------------- COUNT-UP NUMBER -----------------------------
+   Imperative 0 → target count-up on a ref (no per-frame React re-render),
+   driven by `playToken` so it re-fires on every TRUE viewport re-entry and
+   holds at 0 before the first entry. Uses the shared `animateToTarget`
+   (fast-start / slow-finish curve) and clamps exactly on the target. Honours
+   reduced motion by painting the final value with no tween. The animated
+   digits are `aria-hidden` and an `sr-only` span carries the final value, so
+   assistive tech never hears the intermediate "0" (mirrors StatsCard). */
+function StreakNumber({
+  target = 0,
+  playToken,
+  prefersReducedMotion,
+  className = "",
+  style,
+  srLabel,
+}) {
+  const ref = useRef(null);
+  const safe = Number(target) || 0;
 
-                {/* Divider */}
-                <div className="sm:block w-px h-32 bg-white sm:mx-4 mx-1 hidden" />
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return undefined;
+    if (prefersReducedMotion) {
+      node.textContent = String(safe);
+      return undefined;
+    }
+    if (playToken === 0) {
+      // Pre-entry: hold at 0 so the first true entry plays a full sweep.
+      node.textContent = "0";
+      return undefined;
+    }
+    const cancel = animateToTarget({
+      from: 0,
+      to: safe,
+      duration: COUNT_UP_MS,
+      onUpdate: (v) => {
+        node.textContent = String(Math.round(v));
+      },
+    });
+    return cancel;
+  }, [playToken, safe, prefersReducedMotion]);
 
-                {/* Current Streak with Circle */}
-                <motion.div
-                    initial={{ opacity: 0, scale: 0.9 }}
-                    animate={isInView ? { opacity: 1, scale: 1 } : {}}
-                    transition={{ duration: 0.6, ease: "easeOut" }}
-                    className="flex flex-col items-center flex-1 text-center"
-                >
-                    <div className="relative sm:w-24 sm:h-24 h-20 w-20 flex items-center justify-center mb-2">
-                        <svg
-                            className="absolute w-full h-full"
-                            viewBox="0 0 120 120"
-                            style={{ transform: "rotate(-90deg)" }}
-                        >
-                            <circle
-                                cx="60"
-                                cy="60"
-                                r="55"
-                                fill="none"
-                                stroke="rgba(217, 119, 6, 0.2)"
-                                strokeWidth="4"
-                            />
-                            <motion.circle
-                                cx="60"
-                                cy="60"
-                                r="55"
-                                fill="none"
-                                stroke="rgb(217, 119, 6)"
-                                strokeWidth="6"
-                                strokeDasharray="345"
-                                strokeDashoffset="345"
-                                initial={{ strokeDashoffset: 345 }}
-                                animate={isInView ? { strokeDashoffset: 0 } : { strokeDashoffset: 345 }}
-                                transition={{ duration: 1.5, ease: "easeOut", delay: 0.3 }}
-                                strokeLinecap="round"
-                            />
-                        </svg>
-                        <div className="flex items-center justify-center absolute top-1 -translate-y-1/2 left-1/2 -translate-x-1/2 bg-[#0F000F] px-1">
-                            <Flame size={24} fill="#ffaa2a" style={{ color: "#ffaa2a" }} />
-                        </div>
-
-                        <AnimatedNumber
-                            target={currentStreak?.value}
-                            isInView={isInView}
-                            className="text-3xl md:text-4xl font-bold text-shadow-neon-light-orange z-10"
-                            duration={1000}
-                        />
-                    </div>
-                    <div className="text-sm md:text-base mb-1 text-shadow-neon-light-orange font-semibold" style={{ textShadow: "none" }}>Current Streak</div>
-                    <div className="text-[10px] sm:text-xs md:text-sm text-shadow-neon-light-orange font-light" style={{ textShadow: "none" }}>{currentStreak?.dateRange}</div>
-                </motion.div>
-
-                {/* Divider */}
-                <div className="sm:block w-px h-32 bg-white sm:mx-4 mx-1 hidden" />
-
-                {/* Longest Streak */}
-                <AnimatedStatBlock
-                    title="Longest Streak"
-                    value={longestStreak?.value}
-                    dateRange={longestStreak?.dateRange}
-                    isInView={isInView}
-                    align="end"
-                    delay={0.2}
-                />
-            </div>
-        </motion.div>
-    );
+  return (
+    <span className={className} style={style}>
+      <span className="sr-only">{srLabel ?? safe}</span>
+      <span ref={ref} aria-hidden="true">
+        {prefersReducedMotion ? safe : 0}
+      </span>
+    </span>
+  );
 }
 
-/* --------------------- Reusable Stat Block --------------------- */
-function AnimatedStatBlock({ title, value, dateRange, isInView, align = "center", delay = 0 }) {
-    return (
-        <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={isInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.5, ease: "easeOut", delay }}
-            className={`flex flex-col items-center md:items-${align} flex-1 text-center md:text-${align}`}
-        >
-            <AnimatedNumber
-                target={value}
-                isInView={isInView}
-                className="text-2xl md:text-3xl font-bold text-[#ff6d05] mb-2 text-center w-full"
-            />
-            <div className="text-sm md:text-base mb-1 w-full font-semibold text-shadow-neon-light-orange" style={{ textShadow: "none" }}>{title}</div>
-            <div className="text-[10px] sm:text-xs md:text-sm w-full text-shadow-neon-light-orange font-light" style={{ textShadow: "none" }}>{dateRange}</div>
-        </motion.div>
-    );
+/* ------------------------------- STAT BLOCK -------------------------------
+   Total Contributions / Longest Streak: a count-up number, a fire-amber
+   label, and a static (never animated) muted-gold date range. */
+function StatBlock({ label, value, dateRange, playToken, prefersReducedMotion }) {
+  return (
+    <div className="flex flex-col items-center justify-center flex-1 text-center min-w-0">
+      <StreakNumber
+        target={Number(value) || 0}
+        playToken={playToken}
+        prefersReducedMotion={prefersReducedMotion}
+        className="text-2xl sm:text-3xl lg:text-4xl font-bold tabular-nums mb-2"
+        style={{ color: ORANGE, textShadow: "none" }}
+      />
+      <span
+        className="text-sm md:text-base mb-1 font-semibold text-fire-amber"
+        style={{ textShadow: "none" }}
+      >
+        {label}
+      </span>
+      <span
+        className="text-[10px] sm:text-xs md:text-sm font-light break-words"
+        style={{ color: DATE_TONE }}
+      >
+        {dateRange}
+      </span>
+    </div>
+  );
 }
 
-/* ------------------- Animated Number (0 → value) ------------------- */
-function AnimatedNumber({ target = 0, isInView, duration = 1200, className }) {
-    const [display, setDisplay] = useState(0);
+// Vertical gradient divider — a faded amber line that dissolves at both ends,
+// replacing the previous flat white rule. Hidden on the stacked mobile layout.
+function Divider() {
+  return (
+    <div
+      aria-hidden="true"
+      className="hidden sm:block w-px self-stretch my-2 mx-1 shrink-0"
+      style={{
+        background:
+          "linear-gradient(to bottom, transparent, rgba(255,170,42,0.45), transparent)",
+      }}
+    />
+  );
+}
 
-    useEffect(() => {
-        if (!isInView) {
-            setDisplay(0);
-            return;
-        }
+export default function StreakStatsCard({ data }) {
+  const cardRef = useRef(null);
+  // Latched, hysteresis-debounced viewport trigger: `playToken` re-fires the
+  // count-ups + ring sweep on each TRUE re-entry (never loops while the card
+  // stays visible, and absorbs the IntersectionObserver flicker that the raw
+  // observer would emit during the parent ItemLayout's scale entrance);
+  // `isInView` gates the banner's visual. `hasEntered` drives the one-shot
+  // entrance so that flicker can't replay the fade.
+  const { isInView, playToken } = useViewportCountTrigger(cardRef, {
+    amount: 0.3,
+    margin: "-50px",
+  });
+  const hasEntered = playToken > 0;
+  const prefersReducedMotion = useReducedMotion();
 
-        let startTime;
-        const animate = (timestamp) => {
-            if (!startTime) startTime = timestamp;
-            const progress = Math.min((timestamp - startTime) / duration, 1);
-            setDisplay(Math.floor(progress * target));
-            if (progress < 1) requestAnimationFrame(animate);
-        };
-        requestAnimationFrame(animate);
-    }, [isInView, target, duration]);
+  const { totalContributions, currentStreak, longestStreak } = data || {};
 
-    return <div className={`${className} text-shadow-neon-light-orange`}>{display}</div>;
+  // --- Smart update banner (issue #21) ---
+  const { pendingMessage, consume } = useStreakUpdateSignal(data);
+  const [bannerMessage, setBannerMessage] = useState(null);
+  // Capture the pending message as soon as it exists — NOT gated on viewport —
+  // so UpdateBanner's always-mounted aria-live region announces the change
+  // immediately (AT users navigate by structure, not by scrolling here).
+  // consume() advances the localStorage baseline so a reload doesn't replay it.
+  useEffect(() => {
+    if (!pendingMessage) return;
+    setBannerMessage(pendingMessage);
+    consume();
+  }, [pendingMessage, consume]);
+  // Auto-hide the VISUAL banner ~4.5s after the card is actually in view (timer
+  // restarts on each entry), so an update detected off-screen isn't dismissed
+  // unseen. consume() above only nulls pendingMessage, not this timer.
+  useEffect(() => {
+    if (!bannerMessage || !isInView) return undefined;
+    const timer = setTimeout(() => setBannerMessage(null), BANNER_VISIBLE_MS);
+    return () => clearTimeout(timer);
+  }, [bannerMessage, isInView]);
+
+  // Current streak as a fraction of the personal best — the ring visualises
+  // "how close is the current streak to your longest?". Clamped to [0,1];
+  // falls back to a full ring when there's an active streak but no recorded
+  // longest, and an empty ring when there's no current streak.
+  const current = Number(currentStreak?.value) || 0;
+  const longest = Number(longestStreak?.value) || 0;
+  const fraction =
+    longest > 0 ? Math.min(current / longest, 1) : current > 0 ? 1 : 0;
+  const filledOffset = RING_CIRCUMFERENCE * (1 - fraction);
+  // Personal best: the current run has caught (or matched) the all-time
+  // longest. This is the card's hero moment — it lights the ring hotter and
+  // surfaces the "Personal best" badge below the current-streak label.
+  const isPeak = current > 0 && current >= longest;
+  const ringSrLabel =
+    longest > 0
+      ? `${current} day${current === 1 ? "" : "s"}, ${Math.round(
+          fraction * 100
+        )} percent of your longest streak`
+      : `${current} day${current === 1 ? "" : "s"}`;
+
+  return (
+    // `repo-card-breathe rounded-lg` matches the sibling cards' inner chrome
+    // (the breathing orange halo on a rounded perimeter inside the ItemLayout's
+    // amber `custom-bg-abt` border). The original opacity/y entrance is
+    // preserved but driven off `hasEntered` so it plays once cleanly.
+    <motion.div
+      ref={cardRef}
+      initial={{ opacity: 0, y: prefersReducedMotion ? 0 : 30 }}
+      animate={
+        hasEntered
+          ? { opacity: 1, y: 0 }
+          : { opacity: 0, y: prefersReducedMotion ? 0 : 30 }
+      }
+      transition={{ duration: 0.6, ease: "easeOut" }}
+      className="repo-card-breathe rounded-lg w-full h-full relative overflow-hidden p-5 sm:p-6 flex flex-col justify-center"
+    >
+      <UpdateBanner
+        message={bannerMessage}
+        visible={isInView}
+        srPrefix="Streaks update: "
+        variant="orange"
+      />
+
+      {/* Eyebrow — same microlabel treatment as the sibling cards. */}
+      <p
+        aria-hidden="true"
+        className="text-[10px] uppercase tracking-[0.22em] mb-4 sm:mb-5"
+        style={{ color: AMBER, textShadow: "none" }}
+      >
+        Contribution streaks
+      </p>
+
+      <div className="flex flex-col sm:flex-row items-stretch justify-between gap-5 sm:gap-2">
+        {/* Total Contributions */}
+        <StatBlock
+          label="Total Contributions"
+          value={totalContributions?.value}
+          dateRange={totalContributions?.dateRange}
+          playToken={playToken}
+          prefersReducedMotion={prefersReducedMotion}
+        />
+
+        <Divider />
+
+        {/* Current Streak — count-up centred in a progress ring whose fill
+            shows the current streak as a share of the longest. */}
+        <div className="flex flex-col items-center justify-center flex-1 text-center min-w-0">
+          <div className="relative w-20 h-20 sm:w-24 sm:h-24 lg:w-28 lg:h-28 flex items-center justify-center mb-2">
+            <svg
+              className="absolute w-full h-full"
+              viewBox="0 0 120 120"
+              style={{ transform: "rotate(-90deg)" }}
+              aria-hidden="true"
+            >
+              <circle
+                cx="60"
+                cy="60"
+                r={RING_RADIUS}
+                fill="none"
+                stroke={RING_TRACK}
+                strokeWidth="6"
+              />
+              {/* `key={playToken}` remounts the arc on each true entry so the
+                  sweep replays; pre-entry (playToken 0 → hasEntered false) it
+                  holds empty. Reduced motion snaps to the filled offset. */}
+              <motion.circle
+                key={playToken}
+                className={
+                  isPeak ? "streak-ring-glow--peak" : "streak-ring-glow"
+                }
+                cx="60"
+                cy="60"
+                r={RING_RADIUS}
+                fill="none"
+                stroke={ORANGE}
+                strokeWidth="6"
+                strokeLinecap="round"
+                strokeDasharray={RING_CIRCUMFERENCE}
+                initial={{ strokeDashoffset: RING_CIRCUMFERENCE }}
+                animate={{
+                  strokeDashoffset: hasEntered
+                    ? filledOffset
+                    : RING_CIRCUMFERENCE,
+                }}
+                transition={
+                  prefersReducedMotion
+                    ? { duration: 0 }
+                    : { duration: 1.5, ease: fastStartSlowFinish, delay: 0.2 }
+                }
+              />
+            </svg>
+            {/* Git commit node sitting on the streak ring — the latest commit
+                on the branch of your contribution streak. A soft amber glow
+                lifts it off the ring stroke (no hard mask box); a gentle pulse
+                gives it life (held steady under reduced motion). */}
+            <span
+              aria-hidden="true"
+              className="absolute -top-0.5 left-1/2 -translate-x-1/2 -translate-y-1/2"
+            >
+              <motion.span
+                className="block origin-center"
+                animate={
+                  prefersReducedMotion
+                    ? undefined
+                    : { scale: [1, 1.12, 1], opacity: [0.9, 1, 0.9] }
+                }
+                transition={
+                  prefersReducedMotion
+                    ? undefined
+                    : { duration: 2.2, repeat: Infinity, ease: "easeInOut" }
+                }
+              >
+                <GitCommitVertical
+                  size={26}
+                  style={{
+                    color: AMBER,
+                    filter: "drop-shadow(0 0 5px rgba(255,170,42,0.7))",
+                  }}
+                />
+              </motion.span>
+            </span>
+            <StreakNumber
+              target={current}
+              playToken={playToken}
+              prefersReducedMotion={prefersReducedMotion}
+              srLabel={ringSrLabel}
+              className="z-10 text-2xl sm:text-3xl lg:text-4xl font-bold tabular-nums"
+              style={{ color: ORANGE, textShadow: "none" }}
+            />
+          </div>
+          <span
+            className="text-sm md:text-base mb-1 font-semibold text-fire-amber"
+            style={{ textShadow: "none" }}
+          >
+            Current Streak
+          </span>
+          <span
+            className="text-[10px] sm:text-xs md:text-sm font-light break-words"
+            style={{ color: DATE_TONE }}
+          >
+            {currentStreak?.dateRange}
+          </span>
+          {/* Peak badge — only when the current run has matched the all-time
+              best. Subtle gold pill that celebrates the moment without
+              competing with the headline numbers. */}
+          {isPeak && (
+            <motion.span
+              initial={{ opacity: 0, scale: 0.85 }}
+              animate={
+                hasEntered
+                  ? { opacity: 1, scale: 1 }
+                  : { opacity: 0, scale: 0.85 }
+              }
+              transition={{ duration: 0.4, ease: "easeOut", delay: 0.6 }}
+              className="mt-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em]"
+              style={{
+                color: AMBER,
+                background: "rgba(255,170,42,0.10)",
+                border: "1px solid rgba(255,170,42,0.30)",
+              }}
+            >
+              <Flame size={9} fill={AMBER} style={{ color: AMBER }} aria-hidden="true" />
+              Personal best
+            </motion.span>
+          )}
+        </div>
+
+        <Divider />
+
+        {/* Longest Streak */}
+        <StatBlock
+          label="Longest Streak"
+          value={longestStreak?.value}
+          dateRange={longestStreak?.dateRange}
+          playToken={playToken}
+          prefersReducedMotion={prefersReducedMotion}
+        />
+      </div>
+    </motion.div>
+  );
 }

--- a/src/components/about/StreakStatsCard.jsx
+++ b/src/components/about/StreakStatsCard.jsx
@@ -164,8 +164,9 @@ export default function StreakStatsCard({ data }) {
   // stays visible, and absorbs the IntersectionObserver flicker that the raw
   // observer would emit during the parent ItemLayout's scale entrance);
   // `settledInView` (debounced + reversible) drives the card's fade/slide
-  // entrance so it replays on every re-entry; `isInView` gates the banner.
-  const { isInView, playToken, settledInView } = useViewportCountTrigger(cardRef, {
+  // entrance AND gates the banner overlay, so both ride out the same flicker
+  // that raw `isInView` would expose as on/off jitter.
+  const { playToken, settledInView } = useViewportCountTrigger(cardRef, {
     amount: 0.3,
     margin: "-50px",
   });
@@ -190,14 +191,16 @@ export default function StreakStatsCard({ data }) {
     setBannerMessage(pendingMessage);
     consume();
   }, [pendingMessage, consume]);
-  // Auto-hide the VISUAL banner ~4.5s after the card is actually in view (timer
-  // restarts on each entry), so an update detected off-screen isn't dismissed
-  // unseen. consume() above only nulls pendingMessage, not this timer.
+  // Auto-hide the VISUAL banner ~4.5s after it actually paints (timer restarts
+  // on each settled entry), so an update detected off-screen isn't dismissed
+  // unseen. Gated on `settledInView` — the same signal the banner paints on —
+  // so flicker can't restart the timer while the banner stays visible.
+  // consume() above only nulls pendingMessage, not this timer.
   useEffect(() => {
-    if (!bannerMessage || !isInView) return undefined;
+    if (!bannerMessage || !settledInView) return undefined;
     const timer = setTimeout(() => setBannerMessage(null), BANNER_VISIBLE_MS);
     return () => clearTimeout(timer);
-  }, [bannerMessage, isInView]);
+  }, [bannerMessage, settledInView]);
 
   // Current streak as a fraction of the personal best — the ring visualises
   // "how close is the current streak to your longest?". Clamped to [0,1];
@@ -233,7 +236,7 @@ export default function StreakStatsCard({ data }) {
     >
       <UpdateBanner
         message={bannerMessage}
-        visible={isInView}
+        visible={settledInView}
         srPrefix="Streaks update: "
         variant="orange"
       />

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -1396,7 +1396,7 @@ const AboutDetails = () => {
         </ItemLayout>
 
         {githubStats?.stats && <ItemLayout className={"col-span-full lg:col-span-6 !p-0"}>
-          <StreakStatsCard data={githubStats.stats.streaks} isUpdated={changedFields.includes("stats.streaks")} />
+          <StreakStatsCard data={githubStats.stats.streaks} />
         </ItemLayout>}
 
 

--- a/src/components/about/index.jsx
+++ b/src/components/about/index.jsx
@@ -11,6 +11,7 @@ import { computeRepoDiff } from "@/utils/repoDiff";
 import { computeStatsDiff } from "@/utils/statsDiff";
 import { useExperienceSummary } from "@/hooks/useExperienceSummary";
 import { useProjectCountSignal } from "@/hooks/useProjectCountSignal";
+import { useReliableInView } from "@/hooks/useReliableInView";
 import { ExperienceBreakdownModal } from "./ExperienceBreakdownModal";
 import { ExperienceUpdateBanner } from "./ExperienceUpdateBanner";
 import { UpdateBanner } from "./UpdateBanner";
@@ -207,6 +208,36 @@ function CountUp({ value, inView = true }) {
   useViewportCountUp(nodeRef, { to: value, inView, prefersReducedMotion });
 
   return <span ref={nodeRef}>{prefersReducedMotion ? value : 0}</span>;
+}
+
+// Big-digit count-up for the "Completed projects" and "Years in the craft"
+// cards. The count-up + debounced viewport replay live in the shared
+// `useViewportCountUp` hook (see its definition for the hysteresis rationale).
+// `inView` (default true) gates the replay; reduced motion writes `to` straight
+// to the node, and the JSX initialiser uses the same gate so the first paint is
+// already final under reduced motion.
+//
+// MUST live at module scope (not nested in AboutDetails): a component defined
+// inside another is a NEW type every parent render, so React unmounts and
+// remounts it on each AboutDetails update (hydrate, experience load, polling).
+// That reset the count-up to `from` and restarted the tween before it could
+// finish — the digit was stuck at 0. Hoisting keeps it mounted so the tween
+// runs once to completion.
+function Counter({ from = 0, to, plusIcon = true, inView = true }) {
+  const nodeRef = useRef(null);
+  const prefersReducedMotion = useReducedMotion();
+
+  useViewportCountUp(nodeRef, { from, to, inView, prefersReducedMotion });
+
+  return (
+    // Inline elements only: this renders inside the cards' <h1>, and a
+    // heading may contain phrasing content only — a block <div>/<p> here is
+    // invalid HTML. `inline-flex` keeps the digit (+ optional plus) aligned.
+    <span className="inline-flex items-center justify-center">
+      <span ref={nodeRef}>{prefersReducedMotion ? to : from}</span>
+      {plusIcon && <span>+</span>}
+    </span>
+  );
 }
 
 // Two-segment proportional bar shown under the years digit on the
@@ -617,28 +648,6 @@ const AboutDetails = () => {
     [0, 1]
   );
 
-  // Counter Animation — the count-up + debounced viewport replay live in the
-  // shared `useViewportCountUp` hook (see its definition for the hysteresis
-  // rationale). `inView` (default true) gates the replay; reduced motion writes
-  // `to` straight to the node, and the JSX initialiser uses the same gate so
-  // the first paint is already final under reduced motion.
-  function Counter({ from, to, plusIcon = true, inView = true }) {
-    const nodeRef = useRef(null);
-    const prefersReducedMotion = useReducedMotion();
-
-    useViewportCountUp(nodeRef, { from, to, inView, prefersReducedMotion });
-
-    return (
-      // Inline elements only: this renders inside the cards' <h1>, and a
-      // heading may contain phrasing content only — a block <div>/<p> here is
-      // invalid HTML. `inline-flex` keeps the digit (+ optional plus) aligned.
-      <span className="inline-flex items-center justify-center">
-        <span ref={nodeRef}>{prefersReducedMotion ? to : from}</span>
-        {plusIcon && <span>+</span>}
-      </span>
-    );
-  }
-
   // Issue #17: years is now driven by the experience-summary API
   // (GitHub earliest-repo date + software roles parsed from the resume
   // PDF) instead of a hardcoded `startDate`. The hook fetches once per
@@ -687,12 +696,24 @@ const AboutDetails = () => {
   // overlay — same z-index regardless of which card opened it.
   const [isExperienceModalOpen, setIsExperienceModalOpen] = useState(false);
   const experienceTriggerRef = useRef(null);
+  // Viewport observer for the count-up + banner. Deliberately a SEPARATE ref
+  // on the inner (non-scaled) card div rather than reusing `experienceTriggerRef`
+  // on the outer ItemLayout: the ItemLayout animates `scale 0 → 1` on entry, and
+  // an IntersectionObserver attached to that self-scaling element reads zero area
+  // at entry and never re-fires after the transform settles — so `useInView`
+  // stuck false and the years count-up sat at 0. The inner div isn't the scale
+  // target, so its observer reads a true ratio. `experienceTriggerRef` stays on
+  // the ItemLayout because the modal restores focus to that focusable button.
+  const experienceInViewRef = useRef(null);
   // Banner visibility driver. The banner component dedupes per
   // message internally, so re-entering the card while the same
   // message is "in flight" won't restart the timer; only a fresh
   // change-message from the next poll will fire it again.
-  const isExperienceCardInView = useInView(experienceTriggerRef, {
-    once: false,
+  // `useReliableInView` (not framer `useInView`) because the ItemLayout's
+  // `scale 0 → 1` entrance blinds an IntersectionObserver to the card — see the
+  // hook's own docs. Measures real geometry so the count-up fires on /about
+  // where this card is on screen at load and never gets a re-triggering scroll.
+  const isExperienceCardInView = useReliableInView(experienceInViewRef, {
     amount: 0.5,
   });
   const openExperienceModal = () => {
@@ -1069,8 +1090,10 @@ const AboutDetails = () => {
   // languages card). Shown via the shared UpdateBanner once the card is in
   // view, then auto-hidden after ~4.5s.
   const completedProjectsRef = useRef(null);
-  const isCompletedProjectsInView = useInView(completedProjectsRef, {
-    once: false,
+  // `useReliableInView` (not framer `useInView`): the ItemLayout's scale 0 → 1
+  // entrance hides the card from an IntersectionObserver, so the count-up never
+  // fired and the digit sat at 0 on /about. See the hook's docs.
+  const isCompletedProjectsInView = useReliableInView(completedProjectsRef, {
     amount: 0.3,
   });
   const { pendingMessage: projectCountPending, consume: consumeProjectCount } =
@@ -1165,7 +1188,6 @@ const AboutDetails = () => {
         </ItemLayout>
 
         <ItemLayout
-          ref={completedProjectsRef}
           // Mirrors the "Years in the craft" card exactly: `!p-0` hands all
           // padding to the inner `repo-card-breathe` wrapper, and `group
           // relative` matches the sibling so the two feature cards share one
@@ -1175,8 +1197,17 @@ const AboutDetails = () => {
         >
           {/* Inner wrapper is the 1:1 twin of the years card's: the
               `repo-card-breathe` pulsing glow border on a `rounded-lg`
-              perimeter, padded `p-6`, content flex-col centered. */}
-          <div className="repo-card-breathe relative w-full h-full overflow-hidden rounded-lg px-6 py-4 flex flex-col items-stretch justify-center">
+              perimeter, padded `p-6`, content flex-col centered.
+
+              The viewport observer (`completedProjectsRef`) lives HERE on the
+              inner div, NOT on the outer ItemLayout: the ItemLayout animates
+              `scale 0 → 1` on entry, and an IntersectionObserver attached to
+              that self-scaling element reads zero area at entry and never
+              re-fires after the transform settles — leaving `useInView` stuck
+              false so the count-up never ran (the digit sat at 0). The inner
+              div is not the scale target, so its observer reads a true ratio.
+              Same reason the sibling stat cards observe their inner card. */}
+          <div ref={completedProjectsRef} className="repo-card-breathe relative w-full h-full overflow-hidden rounded-lg px-6 py-4 flex flex-col items-stretch justify-center">
             {/* Count-change banner — appears only when the completed-projects
                 count changed since this device last saw it (issue #16). The
                 UpdateBanner's nodes are both out-of-flow (sr-only is absolute,
@@ -1262,7 +1293,7 @@ const AboutDetails = () => {
               The content's flex-col stack + vertical centering moved
               from the outer to this inner so layout behaviour is
               unchanged after the restructure. */}
-          <div className="repo-card-breathe relative w-full h-full overflow-hidden rounded-lg px-6 py-4 flex flex-col items-stretch justify-center">
+          <div ref={experienceInViewRef} className="repo-card-breathe relative w-full h-full overflow-hidden rounded-lg px-6 py-4 flex flex-col items-stretch justify-center">
             <ExperienceUpdateBanner
               message={testExperienceMessage ?? experienceChangeMessage}
               inView={isExperienceCardInView}

--- a/src/hooks/useLanguagesUpdateSignal.js
+++ b/src/hooks/useLanguagesUpdateSignal.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { diffLanguages, languagesFingerprint } from "@/utils/languageDiff";
 
@@ -63,12 +63,6 @@ function writeStored(value) {
 export function useLanguagesUpdateSignal(languages) {
   const [pendingMessage, setPendingMessage] = useState(null);
 
-  // Keep the latest list reachable from the fingerprint-keyed effect
-  // without listing `languages` as a dep (its identity changes every
-  // render and would defeat the fingerprint-only gate).
-  const languagesRef = useRef(languages);
-  languagesRef.current = languages;
-
   const fingerprint =
     Array.isArray(languages) && languages.length > 0
       ? languagesFingerprint(languages)
@@ -76,7 +70,16 @@ export function useLanguagesUpdateSignal(languages) {
 
   useEffect(() => {
     if (!fingerprint) return;
-    const current = languagesRef.current;
+    // Use the `languages` captured by THIS render's closure — the exact list
+    // `fingerprint` was computed from — not a mutable "latest" ref. If a newer
+    // payload commits before this passive effect flushes, a ref would pair an
+    // old `fingerprint` with the newer list, so the stored
+    // `{ fingerprint, languages }` could diff against the wrong baseline and
+    // suppress or misreport the banner. The effect is still gated on
+    // `fingerprint` ALONE (not `languages`, whose identity changes every render
+    // and would re-run it constantly); a fresh-but-equal array produces the same
+    // fingerprint, so the captured snapshot stays value-equivalent.
+    const current = languages;
     const stored = readStored();
 
     if (!stored) {
@@ -93,6 +96,9 @@ export function useLanguagesUpdateSignal(languages) {
     // shows + consumes it.
     writeStored({ fingerprint, languages: current });
     if (diff.hasChanges) setPendingMessage(diff.summaryMessage);
+    // `languages` is intentionally captured by closure, not listed as a dep —
+    // see the comment above; `fingerprint` is the change-only trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fingerprint]);
 
   const consume = useCallback(() => setPendingMessage(null), []);

--- a/src/hooks/useReliableInView.js
+++ b/src/hooks/useReliableInView.js
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * A transform-safe "is this element in view?" hook.
+ *
+ * Why this exists: the about-page cards are wrapped in an `ItemLayout` that
+ * animates `scale 0 → 1` on entry. framer-motion's `useInView` (and a raw
+ * IntersectionObserver) attached anywhere inside that subtree reads the
+ * element's area as ZERO at entry — `transform: scale(0)` collapses the box —
+ * and an IntersectionObserver does NOT re-fire for a transform-only size
+ * change (transforms don't trigger layout, which is what queues observer
+ * notifications). So on the `/about` route, where the "Projects shipped" and
+ * "Years in the craft" cards are already on screen at scroll 0 and never get a
+ * later scroll to nudge the observer, `useInView` stayed stuck `false` and the
+ * count-ups never ran — the digits sat at 0.
+ *
+ * This hook sidesteps that by measuring `getBoundingClientRect()` directly,
+ * which always reflects the LIVE transformed bounds. It checks on scroll/resize
+ * (passive) and, crucially, runs a short `requestAnimationFrame` burst right
+ * after mount so it catches the scale-up settling — the exact window the
+ * IntersectionObserver misses. The rAF burst self-terminates after the
+ * entrance is done; scroll/resize listeners keep it live afterwards.
+ *
+ * `amount` is the fraction of the element's own height that must be visible to
+ * count as in view (mirrors framer's `amount`). Because scale affects the
+ * visible portion and the element height equally, the ratio is scale-invariant
+ * — so it reports correctly even mid-entrance.
+ *
+ * @param {React.RefObject<HTMLElement>} ref
+ * @param {object} [opts]
+ * @param {number} [opts.amount=0.3] - visible-height fraction threshold
+ * @param {number} [opts.settleFrames=45] - rAF ticks (~0.75s) to watch the entrance
+ * @returns {boolean} inView
+ */
+export function useReliableInView(ref, { amount = 0.3, settleFrames = 45 } = {}) {
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof window === "undefined") return undefined;
+
+    let rafId = 0;
+    let frames = 0;
+
+    const check = () => {
+      const r = el.getBoundingClientRect();
+      const vh = window.innerHeight || document.documentElement.clientHeight;
+      // Visible vertical extent of the element within the viewport.
+      const visible = Math.min(r.bottom, vh) - Math.max(r.top, 0);
+      const ratio = r.height > 0 ? visible / r.height : 0;
+      // Functional update so React bails when the value is unchanged — no
+      // re-render churn from the rAF burst once the state has settled.
+      setInView((prev) => {
+        const next = ratio >= amount;
+        return prev === next ? prev : next;
+      });
+    };
+
+    check();
+
+    const onScrollResize = () => check();
+    window.addEventListener("scroll", onScrollResize, { passive: true });
+    window.addEventListener("resize", onScrollResize);
+
+    // Watch the entrance scale-up (a transform the observers can't see) for a
+    // short burst, then stop — scroll/resize keep it accurate from there.
+    const tick = () => {
+      check();
+      if (frames++ < settleFrames) {
+        rafId = window.requestAnimationFrame(tick);
+      }
+    };
+    rafId = window.requestAnimationFrame(tick);
+
+    return () => {
+      window.removeEventListener("scroll", onScrollResize);
+      window.removeEventListener("resize", onScrollResize);
+      if (rafId) window.cancelAnimationFrame(rafId);
+    };
+  }, [ref, amount, settleFrames]);
+
+  return inView;
+}

--- a/src/hooks/useStreakUpdateSignal.js
+++ b/src/hooks/useStreakUpdateSignal.js
@@ -14,19 +14,26 @@ function readStored() {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (raw === null) return null;
     const parsed = JSON.parse(raw);
-    // A valid baseline is an object shaped `{ fingerprint: string, streaks }`.
-    // JSON.parse happily yields non-objects (`true`, `"oops"`, `42`) for a
-    // hand-edited or corrupt entry, and the caller dereferences
-    // `stored.fingerprint` / `stored.streaks` directly — on a primitive that
-    // throws (or on an object missing `fingerprint`, silently misdiffs against
-    // `undefined`). Mirror `useProjectCountSignal`'s read-side validation:
-    // require the parsed shape outright, and treat anything else as no baseline
-    // so the effect's `!stored` branch overwrites it silently. (`typeof null`
-    // is "object", so the explicit null check is load-bearing.)
+    // A valid baseline is an object shaped `{ fingerprint: string, streaks }`
+    // where `streaks` is itself a real streak payload. JSON.parse happily yields
+    // non-objects (`true`, `"oops"`, `42`) for a hand-edited or corrupt entry,
+    // and the caller dereferences `stored.fingerprint` / `stored.streaks`
+    // directly — on a primitive that throws, and on an object whose `streaks` is
+    // missing/garbage (`{ fingerprint: "x" }`, `{ ..., streaks: 42 }`)
+    // `computeStreakDiff` silently diffs against an all-zeros baseline and
+    // fabricates or suppresses a banner. Mirror `useProjectCountSignal`'s
+    // read-side validation: require the full shape outright, and treat anything
+    // else as no baseline so the effect's `!stored` branch overwrites it
+    // silently. (`typeof null` is "object", so the explicit null check is
+    // load-bearing.) `streaks` is validated through `streakFingerprint` — the
+    // same predicate that decides a payload is real elsewhere (non-null object
+    // with at least one tracked block; it returns null for `{}`/primitives) — so
+    // the baseline's notion of "valid streaks" can't drift from the writer's.
     if (
       typeof parsed !== "object" ||
       parsed === null ||
-      typeof parsed.fingerprint !== "string"
+      typeof parsed.fingerprint !== "string" ||
+      streakFingerprint(parsed.streaks) === null
     ) {
       return null;
     }

--- a/src/hooks/useStreakUpdateSignal.js
+++ b/src/hooks/useStreakUpdateSignal.js
@@ -32,9 +32,20 @@ function readStored() {
     if (
       typeof parsed !== "object" ||
       parsed === null ||
-      typeof parsed.fingerprint !== "string" ||
-      streakFingerprint(parsed.streaks) === null
+      typeof parsed.fingerprint !== "string"
     ) {
+      return null;
+    }
+    // Cross-check the stored fingerprint against the one its OWN snapshot
+    // produces. `writeStored` always persists `{ fingerprint, streaks }` as a
+    // matched pair, and `streakFingerprint` is deterministic, so for any honest
+    // entry the recomputed value equals the stored one. A mismatch — null
+    // (garbage/empty `streaks`) or a different string (the fingerprint was
+    // hand-edited, or the snapshot was swapped out from under it) — means the
+    // pair is internally inconsistent and would diff `current` against the WRONG
+    // baseline, fabricating or muting a banner. Treat that as no baseline so the
+    // effect overwrites it silently with a fresh, self-consistent pair.
+    if (streakFingerprint(parsed.streaks) !== parsed.fingerprint) {
       return null;
     }
     return parsed;

--- a/src/hooks/useStreakUpdateSignal.js
+++ b/src/hooks/useStreakUpdateSignal.js
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { computeStreakDiff, streakFingerprint } from "@/utils/streakDiff";
+
+// Single-user site, so one fixed key suffices — mirrors the keying discipline
+// of `useLanguagesUpdateSignal`.
+const STORAGE_KEY = "streak-update:last-seen";
+
+function readStored() {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    // Corrupt entry or storage blocked (private mode) — treat as no baseline
+    // so the banner simply stays silent rather than throwing.
+    return null;
+  }
+}
+
+function writeStored(value) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // QuotaExceeded / private-mode block — we lose the next-visit diff but the
+    // card still renders fine.
+  }
+}
+
+/**
+ * Decides whether the Current Streak update banner should appear, based on
+ * whether the streak stats changed since this device last saw them (issue #21).
+ *
+ * Persists the last-seen fingerprint + streak snapshot in localStorage. When
+ * the current snapshot's fingerprint differs from the stored one, it diffs the
+ * two (via `computeStreakDiff`) and surfaces a human-readable `pendingMessage`
+ * describing exactly what changed. The fingerprint is derived from the data
+ * itself (`streakFingerprint`) — not a server field — so it also works on the
+ * bundled fallback payload and can never drift from the server.
+ *
+ * This is what makes a background update visible: if the streak changes while
+ * the user is already on the About page (a 10-min poll lands new data), the
+ * fingerprint moves, the baseline advances, and `pendingMessage` is set —
+ * the consumer then shows it on the next time the section is in view and calls
+ * `consume()` to clear it.
+ *
+ * Behaviour:
+ *   - First load on a device (no baseline) → record silently, no banner.
+ *   - Fingerprint unchanged → no banner.
+ *   - Fingerprint changed but no tracked field actually moved → no banner
+ *     (advance the baseline anyway so we don't re-diff the same snapshot).
+ *   - Fingerprint changed with a real diff → store the new baseline, expose
+ *     `pendingMessage`.
+ *
+ * Keyed on the fingerprint STRING (not object identity), so it runs only on a
+ * genuine data change — re-renders with a fresh-but-equal object don't re-fire.
+ *
+ * @param {object|null} streaks - `data.stats.streaks`
+ * @returns {{ pendingMessage: string|null, consume: () => void }}
+ */
+export function useStreakUpdateSignal(streaks) {
+  const [pendingMessage, setPendingMessage] = useState(null);
+
+  // Keep the latest snapshot reachable from the fingerprint-keyed effect
+  // without listing `streaks` as a dep (its identity changes every render and
+  // would defeat the fingerprint-only gate).
+  const streaksRef = useRef(streaks);
+  streaksRef.current = streaks;
+
+  const fingerprint = streakFingerprint(streaks);
+
+  useEffect(() => {
+    if (!fingerprint) return;
+    const current = streaksRef.current;
+    const stored = readStored();
+
+    if (!stored) {
+      // No baseline yet — record this snapshot and stay silent.
+      writeStored({ fingerprint, streaks: current });
+      return;
+    }
+    if (stored.fingerprint === fingerprint) return; // nothing changed
+
+    const diff = computeStreakDiff(stored.streaks, current);
+    // Advance the baseline immediately so a reload before the user scrolls
+    // doesn't replay the same banner indefinitely. The message lives in React
+    // state until the section becomes visible and the consumer shows it.
+    writeStored({ fingerprint, streaks: current });
+    if (diff.hasChanged) setPendingMessage(diff.summaryMessage);
+  }, [fingerprint]);
+
+  const consume = useCallback(() => setPendingMessage(null), []);
+
+  return { pendingMessage, consume };
+}

--- a/src/hooks/useStreakUpdateSignal.js
+++ b/src/hooks/useStreakUpdateSignal.js
@@ -12,7 +12,25 @@ function readStored() {
   if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : null;
+    if (raw === null) return null;
+    const parsed = JSON.parse(raw);
+    // A valid baseline is an object shaped `{ fingerprint: string, streaks }`.
+    // JSON.parse happily yields non-objects (`true`, `"oops"`, `42`) for a
+    // hand-edited or corrupt entry, and the caller dereferences
+    // `stored.fingerprint` / `stored.streaks` directly — on a primitive that
+    // throws (or on an object missing `fingerprint`, silently misdiffs against
+    // `undefined`). Mirror `useProjectCountSignal`'s read-side validation:
+    // require the parsed shape outright, and treat anything else as no baseline
+    // so the effect's `!stored` branch overwrites it silently. (`typeof null`
+    // is "object", so the explicit null check is load-bearing.)
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof parsed.fingerprint !== "string"
+    ) {
+      return null;
+    }
+    return parsed;
   } catch {
     // Corrupt entry or storage blocked (private mode) — treat as no baseline
     // so the banner simply stays silent rather than throwing.

--- a/src/hooks/useStreakUpdateSignal.js
+++ b/src/hooks/useStreakUpdateSignal.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { computeStreakDiff, streakFingerprint } from "@/utils/streakDiff";
 
@@ -64,17 +64,21 @@ function writeStored(value) {
 export function useStreakUpdateSignal(streaks) {
   const [pendingMessage, setPendingMessage] = useState(null);
 
-  // Keep the latest snapshot reachable from the fingerprint-keyed effect
-  // without listing `streaks` as a dep (its identity changes every render and
-  // would defeat the fingerprint-only gate).
-  const streaksRef = useRef(streaks);
-  streaksRef.current = streaks;
-
   const fingerprint = streakFingerprint(streaks);
 
   useEffect(() => {
     if (!fingerprint) return;
-    const current = streaksRef.current;
+    // Use the `streaks` captured by THIS render's closure — the exact snapshot
+    // `fingerprint` was computed from — not a mutable "latest" ref. If a newer
+    // payload commits before this passive effect flushes, a ref would pair an
+    // old `fingerprint` with the newer snapshot, so the stored
+    // `{ fingerprint, streaks }` could diff against the wrong baseline and
+    // suppress or misreport the banner. The effect is still gated on
+    // `fingerprint` ALONE (not `streaks`, whose identity changes every render
+    // and would re-run it constantly); a new `streaks` object carrying
+    // identical values produces the same fingerprint, so the captured snapshot
+    // stays value-equivalent.
+    const current = streaks;
     const stored = readStored();
 
     if (!stored) {
@@ -90,6 +94,9 @@ export function useStreakUpdateSignal(streaks) {
     // state until the section becomes visible and the consumer shows it.
     writeStored({ fingerprint, streaks: current });
     if (diff.hasChanged) setPendingMessage(diff.summaryMessage);
+    // `streaks` is intentionally captured by closure, not listed as a dep — see
+    // the comment above; `fingerprint` is the change-only trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fingerprint]);
 
   const consume = useCallback(() => setPendingMessage(null), []);

--- a/src/hooks/useViewportCountTrigger.js
+++ b/src/hooks/useViewportCountTrigger.js
@@ -23,13 +23,22 @@ import { useEffect, useRef, useState } from "react";
  *   - Sustained exit (≥ `leaveDelayMs` outside the viewport) re-arms
  *     the trigger; the next entry increments playToken again.
  *
- * Returns `{ isInView, playToken }`:
+ * Returns `{ isInView, playToken, settledInView }`:
  *   - `isInView` mirrors the underlying observer (use it for things
  *     that should reflect raw visibility, e.g. lazy mounting or
  *     pausing autoplay).
  *   - `playToken` is the latched, hysteresis-debounced trigger value.
  *     A consumer that depends on `[playToken, target]` will animate
  *     when either a real entry happens or the data changes.
+ *   - `settledInView` is a debounced boolean that flips TRUE on a true
+ *     entry and FALSE only after a *sustained* exit (the same
+ *     `leaveDelayMs` hysteresis that re-arms `playToken`). Unlike
+ *     `playToken > 0` — which latches true forever — this reverts, so a
+ *     reversible entrance (fade/slide in, then out off-screen, then in
+ *     again) can REPLAY on every viewport re-entry while still absorbing
+ *     IntersectionObserver flicker. Drive whileInView-style entrances off
+ *     this; drive count-ups/arcs (which key off the trigger value) off
+ *     `playToken`.
  *
  * @param {React.RefObject<HTMLElement>} ref - element to observe
  * @param {object} [options]
@@ -48,11 +57,13 @@ export function useViewportCountTrigger(ref, options = {}) {
 
   const isInView = useInView(ref, { once: false, amount, margin });
 
-  // `playToken` is the only piece of state — every other "is it time to
-  // trigger?" piece of book-keeping lives in refs so it doesn't itself
-  // cause re-renders. The state change happens exactly once per real
-  // entry cycle, which is also the only time consumers want to react.
+  // `playToken` (monotonic trigger count) and `settledInView` (debounced,
+  // reversible visibility) are the only state — all other "is it time to
+  // trigger?" book-keeping lives in refs so it doesn't itself cause
+  // re-renders. `playToken` increments exactly once per real entry cycle;
+  // `settledInView` toggles true on entry and false on sustained exit.
   const [playToken, setPlayToken] = useState(0);
+  const [settledInView, setSettledInView] = useState(false);
 
   // `armedRef` flips false the moment we fire a trigger and only
   // returns to true after the leave-delay timer elapses with the
@@ -75,6 +86,9 @@ export function useViewportCountTrigger(ref, options = {}) {
         clearTimeout(leaveTimerRef.current);
         leaveTimerRef.current = null;
       }
+      // Show the (reversible) entrance immediately on any true visibility —
+      // idempotent, so a flicker that never reset it is a no-op re-render.
+      setSettledInView(true);
       if (armedRef.current) {
         armedRef.current = false;
         setPlayToken((t) => t + 1);
@@ -85,6 +99,9 @@ export function useViewportCountTrigger(ref, options = {}) {
       // mobile momentum scroll past element edges) is absorbed.
       leaveTimerRef.current = setTimeout(() => {
         armedRef.current = true;
+        // Reset the reversible entrance so the NEXT true entry replays it.
+        // Only fires after a sustained exit, so flicker can't reset it.
+        setSettledInView(false);
         leaveTimerRef.current = null;
       }, leaveDelayMs);
     }
@@ -103,5 +120,5 @@ export function useViewportCountTrigger(ref, options = {}) {
     };
   }, []);
 
-  return { isInView, playToken };
+  return { isInView, playToken, settledInView };
 }

--- a/src/utils/animationCurves.js
+++ b/src/utils/animationCurves.js
@@ -34,3 +34,67 @@ export function fastStartSlowFinish(t) {
   const localT = (x - 0.25) / 0.75;
   return 0.7 + 0.3 * (1 - Math.pow(1 - localT, 3));
 }
+
+/**
+ * Imperative count-up tween on `requestAnimationFrame`. Drives a numeric value
+ * `from` → `to` over `duration` ms through `easing`, calling `onUpdate(value)`
+ * each frame and `onComplete()` once at the end. The final frame is clamped to
+ * exactly `to` so the displayed number always lands on the target (rounding a
+ * frame at t≈0.999 could otherwise settle one short).
+ *
+ * Returns a `cancel()` function — call it from an effect cleanup so a re-trigger
+ * (or unmount) stops the in-flight tween instead of leaking competing rAF loops
+ * that fight over the same node.
+ *
+ * SSR / no-rAF safe: when `requestAnimationFrame` is unavailable it paints the
+ * final value synchronously and returns a no-op canceller.
+ *
+ * @param {object}   opts
+ * @param {number}   [opts.from=0]
+ * @param {number}   opts.to
+ * @param {number}   [opts.duration=2000] - ms
+ * @param {(t:number)=>number} [opts.easing=fastStartSlowFinish]
+ * @param {(value:number)=>void} [opts.onUpdate]
+ * @param {() => void} [opts.onComplete]
+ * @returns {() => void} cancel
+ */
+export function animateToTarget({
+  from = 0,
+  to,
+  duration = 2000,
+  easing = fastStartSlowFinish,
+  onUpdate,
+  onComplete,
+} = {}) {
+  if (
+    typeof window === "undefined" ||
+    typeof window.requestAnimationFrame !== "function"
+  ) {
+    onUpdate?.(to);
+    onComplete?.();
+    return () => {};
+  }
+
+  let rafId = 0;
+  let startTs = null;
+  let cancelled = false;
+
+  const tick = (ts) => {
+    if (cancelled) return;
+    if (startTs === null) startTs = ts;
+    const t = duration <= 0 ? 1 : Math.min((ts - startTs) / duration, 1);
+    onUpdate?.(from + (to - from) * easing(t));
+    if (t < 1) {
+      rafId = window.requestAnimationFrame(tick);
+    } else {
+      onUpdate?.(to); // clamp exactly on the target
+      onComplete?.();
+    }
+  };
+
+  rafId = window.requestAnimationFrame(tick);
+  return () => {
+    cancelled = true;
+    if (rafId) window.cancelAnimationFrame(rafId);
+  };
+}

--- a/src/utils/animationCurves.js
+++ b/src/utils/animationCurves.js
@@ -75,6 +75,16 @@ export function animateToTarget({
     return () => {};
   }
 
+  // Nothing to tween: no distance to cover (`from === to`, e.g. a streak value
+  // of 0) or no time to cover it in (`duration <= 0`). Paint the final value
+  // once and finish synchronously instead of scheduling a full rAF loop that
+  // would otherwise spend ~2s repainting the same number every frame.
+  if (from === to || duration <= 0) {
+    onUpdate?.(to);
+    onComplete?.();
+    return () => {};
+  }
+
   let rafId = 0;
   let startTs = null;
   let cancelled = false;

--- a/src/utils/animationCurves.js
+++ b/src/utils/animationCurves.js
@@ -49,6 +49,13 @@ export function fastStartSlowFinish(t) {
  * SSR / no-rAF safe: when `requestAnimationFrame` is unavailable it paints the
  * final value synchronously and returns a no-op canceller.
  *
+ * Input-safe: `from`, `to`, and `duration` are validated as finite numbers
+ * before any tween math runs. A non-finite `to` (e.g. `undefined`/`NaN` from an
+ * unresolved value) has no meaningful target, so the tween is skipped — it
+ * paints the validated start value once and returns a no-op canceller rather
+ * than leaking `NaN`/`undefined` into `onUpdate`. A non-finite or non-positive
+ * `duration` is treated as instant for the same reason.
+ *
  * @param {object}   opts
  * @param {number}   [opts.from=0]
  * @param {number}   opts.to
@@ -66,21 +73,33 @@ export function animateToTarget({
   onUpdate,
   onComplete,
 } = {}) {
+  // Validate numeric inputs up front. This is an exported shared utility, so a
+  // caller passing `to: undefined`/`NaN` (or a `NaN` duration) must never reach
+  // the tween math — `from + (to - from) * easing(t)` would otherwise push
+  // `NaN`/`undefined` straight into `onUpdate` and the UI. Fall back to a finite
+  // start value (default 0) and a non-finite duration to "instant".
+  const safeFrom = Number.isFinite(from) ? from : 0;
+  const safeDuration = Number.isFinite(duration) ? duration : 0;
+  const hasValidTarget = Number.isFinite(to);
+  // When `to` is invalid there is no destination to land on, so the safest paint
+  // is the validated start value rather than the bogus `to`.
+  const safeValue = hasValidTarget ? to : safeFrom;
+
   if (
     typeof window === "undefined" ||
     typeof window.requestAnimationFrame !== "function"
   ) {
-    onUpdate?.(to);
+    onUpdate?.(safeValue);
     onComplete?.();
     return () => {};
   }
 
-  // Nothing to tween: no distance to cover (`from === to`, e.g. a streak value
-  // of 0) or no time to cover it in (`duration <= 0`). Paint the final value
-  // once and finish synchronously instead of scheduling a full rAF loop that
-  // would otherwise spend ~2s repainting the same number every frame.
-  if (from === to || duration <= 0) {
-    onUpdate?.(to);
+  // Nothing to tween: invalid target, no distance to cover (`from === to`, e.g.
+  // a streak value of 0), or no time to cover it in (`duration <= 0`). Paint the
+  // final value once and finish synchronously instead of scheduling a full rAF
+  // loop that would otherwise spend ~2s repainting the same number every frame.
+  if (!hasValidTarget || safeFrom === to || safeDuration <= 0) {
+    onUpdate?.(safeValue);
     onComplete?.();
     return () => {};
   }
@@ -92,8 +111,10 @@ export function animateToTarget({
   const tick = (ts) => {
     if (cancelled) return;
     if (startTs === null) startTs = ts;
-    const t = duration <= 0 ? 1 : Math.min((ts - startTs) / duration, 1);
-    onUpdate?.(from + (to - from) * easing(t));
+    // `safeDuration` is guaranteed finite and > 0 here (the early return above
+    // handles every other case), so the ratio is always a finite progress.
+    const t = Math.min((ts - startTs) / safeDuration, 1);
+    onUpdate?.(safeFrom + (to - safeFrom) * easing(t));
     if (t < 1) {
       rafId = window.requestAnimationFrame(tick);
     } else {

--- a/src/utils/streakDiff.js
+++ b/src/utils/streakDiff.js
@@ -149,6 +149,19 @@ export function computeStreakDiff(prev, next) {
  */
 export function streakFingerprint(streaks) {
   if (!streaks || typeof streaks !== "object") return null;
+  // Placeholder guard: the About page seeds state with `streaks: {}` while the
+  // first fetch is in flight (the loading/default shape). That empty object has
+  // NONE of the tracked blocks, so without this check `block()` would coerce
+  // each to `{ value: 0, dateRange: "" }` and return a non-null all-zeros
+  // fingerprint — which the hook would record as a baseline, then flag a false
+  // "updated" banner the instant the first real streak payload arrived. Treat a
+  // payload missing every expected block as ABSENT so the baseline is only
+  // recorded once real data is present.
+  const hasRealBlock =
+    "totalContributions" in streaks ||
+    "currentStreak" in streaks ||
+    "longestStreak" in streaks;
+  if (!hasRealBlock) return null;
   const total = block(streaks, "totalContributions");
   const current = block(streaks, "currentStreak");
   const longest = block(streaks, "longestStreak");

--- a/src/utils/streakDiff.js
+++ b/src/utils/streakDiff.js
@@ -1,0 +1,164 @@
+/**
+ * Diff + fingerprint helpers for the Current Streak card (issue #21).
+ *
+ * Both arguments have the shape of `data.stats.streaks` from
+ * `/api/github-stats`:
+ *
+ *   {
+ *     totalContributions: { value: number, dateRange: string },
+ *     currentStreak:      { value: number, dateRange: string },
+ *     longestStreak:      { value: number, dateRange: string },
+ *   }
+ *
+ * Either may be null/undefined — `prev` is null on the first load (no snapshot
+ * yet) and the whole object can be missing while a fetch is in flight — so the
+ * caller can pass raw state without pre-guarding.
+ *
+ * NOTE on the payload shape vs. the original issue spec: the route exposes a
+ * pre-formatted `dateRange` STRING per block, not separate start/end fields, so
+ * date-change detection diffs that string (a `changed` boolean) rather than
+ * per-endpoint `currentStreakStart` / `currentStreakEnd` deltas. The
+ * `totalContributions` block's range is the rolling 1-year window
+ * ("<a year ago> - Present"), which shifts every day even when nothing
+ * meaningful changed — so its date is deliberately EXCLUDED from both the diff
+ * and the fingerprint to avoid a spurious "dates changed" banner on every
+ * day-rollover. Its numeric `value` is still tracked. The current/longest
+ * ranges are stable unless the streak itself moves, so those are included.
+ */
+
+// Coerce any value to a finite number. `?? 0` (not `|| 0`) preserves a real 0;
+// `Number(...)` tolerates a future string-typed payload. Mirrors statsDiff.
+function num(value) {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// Normalise a streak block ({ value, dateRange }) into a comparable shape.
+function block(streaks, key) {
+  const b = streaks?.[key] ?? {};
+  return { value: num(b.value), dateRange: String(b.dateRange ?? "") };
+}
+
+function emptyCount() {
+  return { prev: 0, current: 0, delta: 0, increased: false };
+}
+
+function emptyDates() {
+  return { prev: "", current: "", changed: false };
+}
+
+function emptyDiff(hasChanged = false) {
+  return {
+    hasChanged,
+    changes: {
+      totalContributions: emptyCount(),
+      currentStreak: emptyCount(),
+      longestStreak: emptyCount(),
+      currentStreakDates: emptyDates(),
+      longestStreakDates: emptyDates(),
+    },
+    summaryMessage: "",
+  };
+}
+
+/**
+ * Compare two streak snapshots. Returns `{ hasChanged: false, ... }` (full
+ * shape, all zeros) when there's nothing meaningful to announce: first load
+ * (`prev` null), either snapshot missing, or no tracked field moved.
+ *
+ * `summaryMessage` joins the changed fields with " | ", e.g.
+ * `"Total Contributions +12 | Current Streak +2"` or
+ * `"Longest Streak +5 | Current Streak dates changed"`. A block's value delta
+ * takes precedence over its date change (a streak that grows changes both, and
+ * the count is the more informative line), so "dates changed" only appears for
+ * a block whose value held but whose range moved.
+ *
+ * @param {object|null} prev - previous streak snapshot, or null on first load
+ * @param {object|null} next - latest streak snapshot
+ */
+export function computeStreakDiff(prev, next) {
+  if (!prev || !next) return emptyDiff(false);
+
+  const p = {
+    total: block(prev, "totalContributions"),
+    current: block(prev, "currentStreak"),
+    longest: block(prev, "longestStreak"),
+  };
+  const c = {
+    total: block(next, "totalContributions"),
+    current: block(next, "currentStreak"),
+    longest: block(next, "longestStreak"),
+  };
+
+  const countField = (a, b) => {
+    const delta = b.value - a.value;
+    return { prev: a.value, current: b.value, delta, increased: delta > 0 };
+  };
+  const dateField = (a, b) => ({
+    prev: a.dateRange,
+    current: b.dateRange,
+    changed: a.dateRange !== b.dateRange,
+  });
+
+  const changes = {
+    totalContributions: countField(p.total, c.total),
+    currentStreak: countField(p.current, c.current),
+    longestStreak: countField(p.longest, c.longest),
+    currentStreakDates: dateField(p.current, c.current),
+    longestStreakDates: dateField(p.longest, c.longest),
+  };
+
+  const messages = [];
+  const pushCount = (label, field) => {
+    if (field.delta !== 0) {
+      const sign = field.delta > 0 ? "+" : "";
+      messages.push(`${label} ${sign}${field.delta}`);
+      return true;
+    }
+    return false;
+  };
+
+  // Value deltas first (most informative). A block's value move suppresses its
+  // own "dates changed" note since the two co-occur when a streak grows.
+  pushCount("Total Contributions", changes.totalContributions);
+  const currentCounted = pushCount("Current Streak", changes.currentStreak);
+  const longestCounted = pushCount("Longest Streak", changes.longestStreak);
+
+  if (!currentCounted && changes.currentStreakDates.changed) {
+    messages.push("Current Streak dates changed");
+  }
+  if (!longestCounted && changes.longestStreakDates.changed) {
+    messages.push("Longest Streak dates changed");
+  }
+
+  const hasChanged = messages.length > 0;
+  return { hasChanged, changes, summaryMessage: messages.join(" | ") };
+}
+
+/**
+ * Deterministic fingerprint of a streak snapshot — a stable, ordered signature
+ * of exactly the fields `computeStreakDiff` tracks (the three values + the
+ * current/longest date ranges; the rolling totalContributions range is
+ * excluded for the reason documented above). Computed client-side from the
+ * data itself (not a server field) so it also works on the bundled fallback
+ * and can never drift from a server value. Returns null for an absent payload
+ * so the caller can skip recording a baseline until real data lands.
+ *
+ * @param {object|null} streaks
+ * @returns {string|null}
+ */
+export function streakFingerprint(streaks) {
+  if (!streaks || typeof streaks !== "object") return null;
+  const total = block(streaks, "totalContributions");
+  const current = block(streaks, "currentStreak");
+  const longest = block(streaks, "longestStreak");
+  // Pipe-joined ordered signature. JSON.stringify of an explicitly-ordered
+  // tuple keeps it deterministic without depending on object key order.
+  return JSON.stringify([
+    total.value,
+    current.value,
+    current.dateRange,
+    longest.value,
+    longest.dateRange,
+  ]);
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features focused on the Current Streak card, including accurate stat tracking, animated UI enhancements, and robust state handling for user-visible updates. The most significant changes are the introduction of a diffing and fingerprinting system for streak data, animated feedback for the streak progress ring, and a custom hook to manage update signals and banners for streak changes. Additionally, there are UI and accessibility improvements, such as ensuring consistent scrollbar colouring on modal return.

**Current Streak tracking and update system:**

- Added `useStreakUpdateSignal` hook to detect and manage changes in streak stats, persisting a fingerprint in localStorage and surfacing a human-readable update banner when relevant fields change. This ensures users are notified only when meaningful streak updates occur.
- Implemented `computeStreakDiff` and `streakFingerprint` utilities to compare streak snapshots and generate stable fingerprints, enabling precise change detection and messaging.

**UI/UX enhancements for streak stats:**

- Replaced the hardcoded total contributions value with the actual calendar total in the streak stats API, ensuring the displayed count and change-diff are accurate.
- Refined the current-streak progress ring: a one-shot fill sweep that replays each time the card enters the viewport, over a clean flat-stroke arc. (An earlier "breathing" glow pulse and a personal-best ring variant for `current === longest` were prototyped but intentionally dropped — along with the "Personal best" badge — for a calmer, less distracting look.)

**Modal and accessibility improvements:**

- Ensured the Experience Breakdown modal's custom scrollbar color is explicitly set and reliably restored when returning from background (e.g., after opening an external link), addressing browser quirks that could cause color loss. [[1]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552R412-R444) [[2]](diffhunk://#diff-9e085f73fc3570001ded111fd0ef4d175510e953cb365f1ce07c0ef5bbe2a552L633-R674)

**Animation utilities:**

- Introduced `animateToTarget`, a robust imperative count-up animation utility using `requestAnimationFrame`, to drive smooth numeric transitions in the UI.

**Refactoring and cleanup:**

- Removed the now-unnecessary `isUpdated` prop from `StreakStatsCard`, as update signalling is now handled by the new custom hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-device streak update banner, local device update signal, and a new imperative count-up animator; more reliable viewport-triggering for replayable animations.

* **Bug Fixes**
  * Current streak now reflects real contribution counts.
  * Modal scrollbar styling persists when returning to the page.

* **Improvements**
  * Replayable, accessible streak and language card animations, improved streak-ring visuals, language list interactive/popover keyboard focus, README/CHANGELOG updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
